### PR TITLE
perf(dashboard): improve scroll performance with paint containment and GPU layer hints

### DIFF
--- a/src/app/components/shared/draggable-card.tsx
+++ b/src/app/components/shared/draggable-card.tsx
@@ -29,6 +29,7 @@ export function DraggableCard({
     ? {
         transform: CSS.Transform.toString(transform),
         transition,
+        willChange: 'transform',
       }
     : {};
 

--- a/src/app/features/dashboard/components/dashboard-card-item.tsx
+++ b/src/app/features/dashboard/components/dashboard-card-item.tsx
@@ -90,7 +90,7 @@ export const DashboardCardItem = memo(function DashboardCardItem({
 
   if (!isEditMode) {
     return (
-      <div className={`relative h-full [contain:layout_style] ${spanClass}`}>{cardContent}</div>
+      <div className={`relative h-full [contain:layout_style_paint] ${spanClass}`}>{cardContent}</div>
     );
   }
 

--- a/src/app/features/dashboard/shell/index.tsx
+++ b/src/app/features/dashboard/shell/index.tsx
@@ -104,7 +104,7 @@ export const DashboardLayout = memo(function DashboardLayout({ children }: Dashb
                     : 'linear-gradient(180deg, rgba(12,18,32,0.98), rgba(7,10,18,0.99))',
             }}
           />
-          {showSharedGlassBlur ? <div className="absolute inset-0 backdrop-blur-[28px]" /> : null}
+          {showSharedGlassBlur ? <div className="absolute inset-0 backdrop-blur-[28px] [transform:translateZ(0)]" /> : null}
         </div>
       )}
 


### PR DESCRIPTION
- dashboard-card-item: upgrade CSS containment from `layout style` to
  `layout style paint` so the browser can skip painting cards that have
  scrolled outside their container's bounds.

- shell: add `transform: translateZ(0)` to the fixed backdrop-blur-[28px]
  div to promote it to its own compositor layer upfront; without this hint
  the browser repaints the blur on every scroll frame when underlying
  content changes.

- draggable-card: set `willChange: 'transform'` on the inline style when a
  card is actively being dragged, letting the browser pre-allocate GPU
  resources for the transform animation instead of promoting the layer
  reactively mid-gesture.

https://claude.ai/code/session_01Bacy1o7dCCaLVUHzfbkr3d