### PR TITLE
Bugfix/room nav scroll and calendar all day

### DIFF
--- a/src/app/components/layout/__tests__/room-nav.test.tsx
+++ b/src/app/components/layout/__tests__/room-nav.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RoomNav } from '@/app/components/layout/room-nav';
+import { renderWithProviders } from '@/test/render';
+import { resetAppStores } from '@/test/store-reset';
+
+describe('RoomNav', () => {
+  beforeEach(async () => {
+    await resetAppStores();
+  });
+
+  function renderRoomNav(onRoomChange = vi.fn()) {
+    const view = renderWithProviders(
+      <RoomNav
+        rooms={['All', 'Living Room', 'Kitchen', 'Bedroom', 'Office', 'Garage']}
+        activeRoom="All"
+        onRoomChange={onRoomChange}
+        isEditMode={false}
+        onToggleEditMode={() => undefined}
+      />
+    );
+
+    const roomScroller = view.container.querySelector<HTMLElement>('.scrollbar-hide');
+
+    if (!roomScroller) {
+      throw new Error('Room scroller not found');
+    }
+
+    Object.defineProperty(roomScroller, 'scrollLeft', {
+      value: 24,
+      writable: true,
+      configurable: true,
+    });
+    roomScroller.setPointerCapture = vi.fn();
+    roomScroller.releasePointerCapture = vi.fn();
+    roomScroller.hasPointerCapture = vi.fn(() => true);
+
+    return { ...view, roomScroller };
+  }
+
+  it('changes room on a normal click', () => {
+    const onRoomChange = vi.fn();
+
+    renderRoomNav(onRoomChange);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Kitchen' }));
+
+    expect(onRoomChange).toHaveBeenCalledWith('Kitchen');
+  });
+
+  it('suppresses room selection after dragging the room scroller', () => {
+    const onRoomChange = vi.fn();
+    const { roomScroller } = renderRoomNav(onRoomChange);
+    const kitchenButton = screen.getByRole('button', { name: 'Kitchen' });
+
+    fireEvent.pointerDown(roomScroller, {
+      button: 0,
+      clientX: 120,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+    fireEvent.pointerMove(roomScroller, {
+      clientX: 72,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+    fireEvent.pointerUp(roomScroller, {
+      clientX: 72,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+    fireEvent.click(kitchenButton);
+
+    expect(roomScroller.scrollLeft).toBe(72);
+    expect(onRoomChange).not.toHaveBeenCalled();
+
+    fireEvent.click(kitchenButton);
+
+    expect(onRoomChange).toHaveBeenCalledWith('Kitchen');
+  });
+});

--- a/src/app/components/layout/room-nav.tsx
+++ b/src/app/components/layout/room-nav.tsx
@@ -1,5 +1,12 @@
 import { Check, ChevronDown, Edit3, GripVertical, LayoutGrid, Lightbulb } from 'lucide-react';
-import { type ButtonHTMLAttributes, forwardRef, memo, useMemo, useState } from 'react';
+import {
+  type ButtonHTMLAttributes,
+  forwardRef,
+  memo,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { InteractivePill } from '@/app/components/primitives/interactive-pill';
 import { getThemeDropdownSurfaceClasses } from '@/app/components/shared/theme/dropdown-surface-tokens';
 import { getThemeSurfaceTokens } from '@/app/components/shared/theme/theme-surface-tokens';
@@ -50,6 +57,13 @@ interface RoomNavMenuButtonProps {
   className: string;
 }
 
+interface RoomNavDragState {
+  pointerId: number;
+  startClientX: number;
+  startScrollLeft: number;
+  moved: boolean;
+}
+
 export const RoomNav = memo(function RoomNav({
   rooms = [],
   roomHiddenItemCounts = new Map(),
@@ -69,6 +83,9 @@ export const RoomNav = memo(function RoomNav({
   const areas = useHomeAssistant(homeAssistantSelectors.areas);
   const surface = getThemeSurfaceTokens(theme);
   const [isReorderDialogOpen, setIsReorderDialogOpen] = useState(false);
+  const roomScrollerRef = useRef<HTMLDivElement | null>(null);
+  const roomNavDragStateRef = useRef<RoomNavDragState | null>(null);
+  const suppressRoomClickRef = useRef(false);
   const manageableRooms = useMemo(() => {
     return getManageableRoomOrder(rooms, areas);
   }, [areas, rooms]);
@@ -102,11 +119,98 @@ export const RoomNav = memo(function RoomNav({
     { label: t('dashboard.roomNav.grouping.none'), value: 'none' },
   ];
 
+  const endRoomNavDrag = (pointerId?: number) => {
+    const roomScroller = roomScrollerRef.current;
+    const dragState = roomNavDragStateRef.current;
+
+    if (!roomScroller || !dragState) {
+      roomNavDragStateRef.current = null;
+      return;
+    }
+
+    if (pointerId !== undefined && dragState.pointerId !== pointerId) {
+      return;
+    }
+
+    if (roomScroller.hasPointerCapture(dragState.pointerId)) {
+      roomScroller.releasePointerCapture(dragState.pointerId);
+    }
+
+    roomNavDragStateRef.current = null;
+  };
+
+  const handleRoomNavPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.pointerType === 'touch' || event.button !== 0) {
+      return;
+    }
+
+    const roomScroller = roomScrollerRef.current;
+
+    if (!roomScroller) {
+      return;
+    }
+
+    roomNavDragStateRef.current = {
+      pointerId: event.pointerId,
+      startClientX: event.clientX,
+      startScrollLeft: roomScroller.scrollLeft,
+      moved: false,
+    };
+  };
+
+  const handleRoomNavPointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    const roomScroller = roomScrollerRef.current;
+    const dragState = roomNavDragStateRef.current;
+
+    if (!roomScroller || !dragState || dragState.pointerId !== event.pointerId) {
+      return;
+    }
+
+    const deltaX = event.clientX - dragState.startClientX;
+
+    if (!dragState.moved && Math.abs(deltaX) < 6) {
+      return;
+    }
+
+    if (!dragState.moved) {
+      dragState.moved = true;
+      suppressRoomClickRef.current = true;
+      roomScroller.setPointerCapture(event.pointerId);
+    }
+
+    event.preventDefault();
+    roomScroller.scrollLeft = dragState.startScrollLeft - deltaX;
+  };
+
+  const handleRoomNavPointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
+    endRoomNavDrag(event.pointerId);
+  };
+
+  const handleRoomNavPointerCancel = (event: React.PointerEvent<HTMLDivElement>) => {
+    endRoomNavDrag(event.pointerId);
+  };
+
+  const handleRoomNavClickCapture = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (suppressRoomClickRef.current) {
+      suppressRoomClickRef.current = false;
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
+
   return (
     <>
       <div className="hidden md:block">
         <div className="flex items-center gap-1.5 md:gap-2">
-          <div className="flex-1 min-w-0 overflow-x-auto scrollbar-hide">
+          <div
+            ref={roomScrollerRef}
+            className="flex-1 min-w-0 overflow-x-auto scrollbar-hide cursor-grab active:cursor-grabbing select-none"
+            onClickCapture={handleRoomNavClickCapture}
+            onPointerCancel={handleRoomNavPointerCancel}
+            onPointerDown={handleRoomNavPointerDown}
+            onPointerMove={handleRoomNavPointerMove}
+            onPointerUp={handleRoomNavPointerUp}
+          >
             <div className="flex min-w-max items-center gap-1.5 md:gap-2">
               {visibleRooms.map((room) => (
                 <RoomNavItem

--- a/src/app/features/calendar/components/calendar/calendar-event-visibility.ts
+++ b/src/app/features/calendar/components/calendar/calendar-event-visibility.ts
@@ -14,10 +14,8 @@ function parseDate(value?: string): Date | null {
   return Number.isNaN(date.getTime()) ? null : date;
 }
 
-function getEndOfDay(date: Date): Date {
-  const endOfDay = new Date(date);
-  endOfDay.setHours(23, 59, 59, 999);
-  return endOfDay;
+function getImplicitAllDayEnd(date: Date): Date {
+  return new Date(date.getTime() + 24 * 60 * 60 * 1000 - 1);
 }
 
 export function getCalendarEventInterval(event: CalendarEvent): CalendarEventInterval {
@@ -31,7 +29,7 @@ export function getCalendarEventInterval(event: CalendarEvent): CalendarEventInt
   if (event.isAllDay && start) {
     return {
       start,
-      end: getEndOfDay(start),
+      end: getImplicitAllDayEnd(start),
     };
   }
 


### PR DESCRIPTION
## Summary

- Adds drag scroll to the room nav bar at the top of the home dashboard if it is wider than the allotted space.
- A test unrelated to this PR was also failling in the calendar, so fixed that as well by changing the way an all-day event is calculated.

## Review checklist

- [X ] Shared UI was added to `src/app/components/primitives/` or `src/app/components/patterns/` when appropriate
- [ X] If this adds shared UI, I can explain why it is not a primitive, pattern, or token when applicable
- [X ] `src/app/components/shared/` was only used for app-specific shared UI or compatibility shims
- [ X] Storybook stories were added or updated for shared UI changes
- [X ] `pnpm check:stories` passes
- [X ] `pnpm check:ui-kit` passes
- [X ] Documentation was updated if Storybook taxonomy, component ownership, or UI system guidance changed
- [ X] I tested responsive behavior where the UI changed
- [ X] I tested relevant theme states where the UI changed
