### PR TITLE
refactor(auth): centralize adapter-driven auth and remove legacy auth-store fallback

### DIFF
--- a/src/app/__tests__/App.test.tsx
+++ b/src/app/__tests__/App.test.tsx
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { resetAppStores } from '@/test/store-reset';
 import App from '../App';
 import { STORAGE_KEYS } from '../constants/storage-keys';
-import { useAuthStore } from '../stores/auth-store';
 
 const CONNECTION_TIMEOUT_MESSAGE =
   'Cannot connect to Home Assistant. Check the saved URL and update it if your Home Assistant address changed.';
@@ -248,11 +247,13 @@ describe('App Home Assistant connection recovery', () => {
 });
 
 function setAuthenticatedSession() {
-  useAuthStore.setState({
-    isAuthenticated: true,
-    config: {
-      url: 'http://192.168.68.71:8123',
-      token: 'token',
-    },
-  });
+  localStorage.setItem(
+    'navet_auth_session',
+    JSON.stringify({
+      hassUrl: 'http://192.168.68.71:8123',
+      accessToken: 'token',
+      refreshToken: 'refresh-token',
+      expiresAt: Date.now() + 3_600_000,
+    })
+  );
 }

--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -1,5 +1,4 @@
 import { createContext, useContext, useEffect, useMemo, useState } from 'react';
-import { useAuthStore } from '@/app/stores/auth-store';
 import { haIngressAuth } from './adapters/haIngressAuth';
 import { haPanelAuth } from './adapters/haPanelAuth';
 import { legacyTokenAuth } from './adapters/legacyTokenAuth';
@@ -33,19 +32,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     localStorage.removeItem('ha_auth_config');
     localStorage.removeItem('ha-dashboard-config');
+    localStorage.removeItem('navet-auth-config');
   }, []);
 
   useEffect(() => {
-    const legacyStoreSession = useAuthStore.getState().config;
-    if (legacyStoreSession?.url && legacyStoreSession?.token) {
-      setSession({
-        hassUrl: legacyStoreSession.url,
-        accessToken: legacyStoreSession.token,
-      });
-      setReady(true);
-      return;
-    }
-
     void adapter.init().then((result) => {
       setSession(result);
       setReady(true);
@@ -63,7 +53,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         setSession(next);
       },
       logout: async () => {
-        useAuthStore.getState().logout();
         setSession(null);
         await adapter.logout?.();
       },

--- a/src/auth/__tests__/adapters.test.ts
+++ b/src/auth/__tests__/adapters.test.ts
@@ -1,9 +1,16 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { haIngressAuth } from '../adapters/haIngressAuth';
 import { haPanelAuth } from '../adapters/haPanelAuth';
 import { legacyTokenAuth } from '../adapters/legacyTokenAuth';
+import { standaloneOAuthAuth } from '../adapters/standaloneOAuthAuth';
 
 describe('auth adapters', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    window.history.replaceState({}, '', '/');
+    vi.restoreAllMocks();
+  });
+
   it('creates panel session', async () => {
     const session = await haPanelAuth.init();
     expect(session?.accessToken).toContain('__ha_panel_session__');
@@ -20,5 +27,39 @@ describe('auth adapters', () => {
       token: 'abc',
     });
     expect(session?.accessToken).toBe('abc');
+  });
+
+  it('restores persisted standalone OAuth session', async () => {
+    localStorage.setItem(
+      'navet_auth_session',
+      JSON.stringify({ hassUrl: 'https://ha.example.com', accessToken: 'token' })
+    );
+    const session = await standaloneOAuthAuth.init();
+    expect(session?.hassUrl).toBe('https://ha.example.com');
+    expect(session?.accessToken).toBe('token');
+  });
+
+  it('refreshes standalone OAuth access tokens', async () => {
+    vi.spyOn(window, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: 'next-access-token',
+          refresh_token: 'next-refresh-token',
+          expires_in: 1800,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+
+    const refreshed = await standaloneOAuthAuth.refresh?.({
+      hassUrl: 'https://ha.example.com',
+      accessToken: 'old',
+      refreshToken: 'old-refresh',
+      expiresAt: Date.now() - 1,
+    });
+
+    expect(refreshed?.accessToken).toBe('next-access-token');
+    expect(refreshed?.refreshToken).toBe('next-refresh-token');
+    expect(localStorage.getItem('navet_auth_session')).toContain('next-access-token');
   });
 });

--- a/src/auth/__tests__/runtime.test.ts
+++ b/src/auth/__tests__/runtime.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { detectAuthRuntime } from '../runtime';
 
 describe('detectAuthRuntime', () => {
+  it('detects panel runtime from embedded flag', () => {
+    (window as { __NAVET_PANEL__?: boolean }).__NAVET_PANEL__ = true;
+    expect(detectAuthRuntime()).toBe('ha-panel');
+    (window as { __NAVET_PANEL__?: boolean }).__NAVET_PANEL__ = false;
+  });
+
   it('detects ingress runtime', () => {
     window.history.replaceState({}, '', '/api/hassio_ingress/navet/dashboard');
     expect(detectAuthRuntime()).toBe('ha-ingress');


### PR DESCRIPTION
### Motivation
- The existing auth-paths were fragile and duplicated legacy URL/token assumptions outside the new adapter layer, so the provider must solely rely on runtime adapters and remove the old `auth-store` fallback.
- Clear legacy localStorage keys during startup to avoid stale credentials being used across runtimes.
- Improve test coverage for all adapters and runtime detection to prevent regressions when completing the larger auth refactor.

### Description
- Removed the legacy `auth-store` session fallback from `src/auth/AuthProvider.tsx` so adapter init results are the single source of truth for the app session and logout behavior.
- Stop calling the old store logout and clear legacy localStorage keys (`ha_auth_config`, `ha-dashboard-config`, and `navet-auth-config`) during provider startup in `src/auth/AuthProvider.tsx`.
- Expanded `src/auth/__tests__/adapters.test.ts` to add standalone-OAuth session restore and refresh-token flow tests and to add a `beforeEach` test setup that clears localStorage and restores mocks.
- Added a `ha-panel` detection test to `src/auth/__tests__/runtime.test.ts` to validate the `__NAVET_PANEL__` embedded flag runtime path.

### Testing
- Ran unit tests: `pnpm vitest run src/auth/__tests__/adapters.test.ts src/auth/__tests__/runtime.test.ts`, all tests passed (2 files, 8 tests passed).
- Pre-commit validation via repository hooks succeeded: `node scripts/check-pnpm-lock-sync.mjs`, `biome check ./src`, `node scripts/check-storybook-standards.mjs`, and `node scripts/check-ui-kit-boundaries.mjs` all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12246af6c8832d9643a590406b2750)