### PR TITLE
feat: refine dashboard and household workflows

### DIFF
--- a/docker/njs/chore-store.js
+++ b/docker/njs/chore-store.js
@@ -1510,10 +1510,18 @@ function applyOccurrenceAction(data, commandId, workspaceAction, timestamp) {
     activityType = 'claimed';
   } else if (action.type === 'complete') {
     assertOccurrenceAssigned(occurrence, action.participantId);
-    if (occurrence.status !== 'available' && occurrence.status !== 'claimed') {
-      throw new Error('Only available or claimed chores can be completed');
+    if (
+      occurrence.status !== 'available' &&
+      occurrence.status !== 'claimed' &&
+      occurrence.status !== 'missed'
+    ) {
+      throw new Error('Only available, claimed, or missed chores can be completed');
     }
-    if (occurrence.status === 'claimed' && occurrence.claimedBy !== action.participantId) {
+    if (
+      (occurrence.status === 'claimed' || occurrence.status === 'missed') &&
+      occurrence.claimedBy &&
+      occurrence.claimedBy !== action.participantId
+    ) {
       throw new Error('A claimed chore can only be completed by its claimant');
     }
     const claimPolicy = isRecord(definition.claimPolicy) ? definition.claimPolicy : {};
@@ -1526,6 +1534,7 @@ function applyOccurrenceAction(data, commandId, workspaceAction, timestamp) {
     nextOccurrence.claimedAt = occurrence.claimedAt || timestamp;
     nextOccurrence.completedBy = action.participantId;
     nextOccurrence.completedAt = timestamp;
+    delete nextOccurrence.missedAt;
     activityType = 'completed';
   } else if (action.type === 'approve' || action.type === 'reject') {
     const approval = isRecord(definition.approval) ? definition.approval : {};

--- a/docs/design-system/UI-GUIDELINES.md
+++ b/docs/design-system/UI-GUIDELINES.md
@@ -112,6 +112,24 @@ Order content by user value:
 4. primary household action
 5. secondary detail and configuration
 
+Visual hierarchy is functional, not decorative. A person should be able to scan a surface and tell
+what the section contains, what each control changes, and which supporting text explains it before
+reading every word.
+
+- Keep hierarchy levels distinct: a section heading names the group, a control title names the
+  setting or action, and a description explains its consequence.
+- Do not use a section heading as a silent replacement for the first control's title. Every control
+  row needs its own visible title when adjacent rows have titles, even when that wording repeats the
+  group context.
+- Never leave helper or description text visually orphaned. It must sit beneath or beside the title
+  it explains, with visibly lower emphasis.
+- Use typography, spacing, alignment, and grouping before adding more borders, backgrounds, badges,
+  or decorative containers.
+- Give sibling controls parallel anatomy. If one option has an icon, title, description, and state
+  control, comparable options in the same group should preserve that reading order.
+- Check the hierarchy at a glance, in every supported theme and at narrow widths. It must remain
+  understandable without relying on color, hover, or prior knowledge of the screen.
+
 Do not add labels, badges, descriptions, or calls to action solely to fill space. Section headings
 organize operational content; they should not become marketing-style hero blocks.
 

--- a/packages/app/src/components/patterns/card-dialog.tsx
+++ b/packages/app/src/components/patterns/card-dialog.tsx
@@ -78,6 +78,7 @@ interface CardDialogChoicePillProps
 interface CardDialogDoneFooterProps {
   label: string;
   className?: string;
+  style?: CSSProperties;
 }
 
 export const CardDialogHeader = memo(function CardDialogHeader({
@@ -283,7 +284,7 @@ export const CardDialogHeader = memo(function CardDialogHeader({
           <Dialog.Description asChild>
             <div
               className={cn(
-                '-mt-0.5 flex min-w-0 flex-wrap items-start gap-1.5',
+                '-mt-0.5 flex min-w-0 flex-wrap items-baseline gap-1.5',
                 'text-sm font-medium',
                 descriptionClassName
               )}
@@ -468,11 +469,11 @@ export function CardDialogFooter({
   );
 }
 
-export function CardDialogDoneFooter({ label, className }: CardDialogDoneFooterProps) {
+export function CardDialogDoneFooter({ label, className, style }: CardDialogDoneFooterProps) {
   return (
     <CardDialogFooter>
       <Dialog.Close asChild>
-        <Button variant="soft" size="small" className={className}>
+        <Button variant="soft" size="small" className={className} style={style}>
           {label}
         </Button>
       </Dialog.Close>

--- a/packages/app/src/components/primitives/Cards/BaseCardDialog/base-card-dialog.test.tsx
+++ b/packages/app/src/components/primitives/Cards/BaseCardDialog/base-card-dialog.test.tsx
@@ -1,0 +1,42 @@
+import { renderWithProviders } from '@navet/app/test/render';
+import { screen } from '@testing-library/react';
+import { Sliders } from 'lucide-react';
+import { describe, expect, it, vi } from 'vitest';
+import { BaseCardDialog } from '.';
+
+describe('BaseCardDialog', () => {
+  it('keeps header actions aligned and inherits the card palette for room and Done controls', () => {
+    renderWithProviders(
+      <BaseCardDialog
+        isOpen
+        onOpenChange={vi.fn()}
+        title="Plant Light"
+        description="Light"
+        theme="dark"
+        tabs={[{ key: 'controls', label: 'Controls', icon: Sliders, content: <div>Controls</div> }]}
+        tintColor="#ff6600"
+        onTitleChange={vi.fn()}
+        roomSelector={{
+          value: 'kitchen',
+          label: 'Kitchen',
+          options: [{ label: 'Kitchen', value: 'kitchen' }],
+          onChange: vi.fn(),
+        }}
+      />
+    );
+
+    const editButton = screen.getByRole('button', { name: /edit plant light/i });
+    expect(editButton.parentElement).toHaveClass('items-baseline');
+
+    const roomSelect = screen.getByRole('combobox', { name: 'Room' });
+    expect(roomSelect.parentElement?.parentElement).toHaveStyle({
+      backgroundColor: 'rgba(255, 102, 0, 0.14)',
+      borderColor: 'rgba(255, 102, 0, 0.24)',
+    });
+
+    expect(screen.getByRole('button', { name: 'Done' })).toHaveStyle({
+      backgroundColor: 'rgba(255, 102, 0, 0.14)',
+      borderColor: 'rgba(255, 102, 0, 0.24)',
+    });
+  });
+});

--- a/packages/app/src/components/primitives/Cards/BaseCardDialog/index.tsx
+++ b/packages/app/src/components/primitives/Cards/BaseCardDialog/index.tsx
@@ -12,9 +12,10 @@ import { TabPanel, Tabs } from '@navet/app/components/primitives/tabs';
 import { CustomCardTintPicker, CustomScrollbar } from '@navet/app/components/shared/device-editor';
 import { CompactRoomSelector } from '@navet/app/components/shared/device-editor/compact-room-selector';
 import { getBaseCardDialogSurface } from '@navet/app/components/shared/theme/base-card-dialog-surface';
+import { getInheritedDialogSectionStyle } from '@navet/app/components/shared/theme/custom-card-tint-surface';
 import { getThemeSurfaceTokens } from '@navet/app/components/shared/theme/theme-surface-tokens';
 import { cn } from '@navet/app/components/ui/utils';
-import { useI18n } from '@navet/app/hooks';
+import { useI18n, useTheme } from '@navet/app/hooks';
 import type { ThemeType } from '@navet/app/hooks/use-theme';
 import * as Dialog from '@radix-ui/react-dialog';
 import { type LucideIcon, Palette, Sliders } from 'lucide-react';
@@ -429,31 +430,22 @@ function BaseCardDialogRoot({
   );
 }
 
-function getWidgetRoomSelector(roomSelector: BaseCardDialogRoomSelector, theme: ThemeType) {
+function getWidgetRoomSelector(
+  roomSelector: BaseCardDialogRoomSelector,
+  theme: ThemeType,
+  controlStyle?: CSSProperties
+) {
   const isLightTheme = theme === 'light';
 
   return (
     <div className="relative inline-flex items-center">
-      {roomSelector.onChange ? (
-        <select
-          aria-label={roomSelector.label}
-          value={roomSelector.value}
-          onChange={(event) => roomSelector.onChange?.(event.target.value)}
-          className="absolute inset-0 z-10 h-full w-full cursor-pointer appearance-none opacity-0 disabled:cursor-not-allowed"
-        >
-          {roomSelector.options.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))}
-        </select>
-      ) : null}
       <div
         className={`inline-flex h-9 min-w-0 items-center rounded-full border px-2.5 ${
           isLightTheme
             ? 'border-slate-300/80 bg-slate-100/90 text-slate-700'
             : 'border-white/12 bg-white/8 text-white/82'
         }`}
+        style={controlStyle}
       >
         <CompactRoomSelector
           value={roomSelector.value}
@@ -478,6 +470,8 @@ function BaseCardDialogCardVariant({
   description,
   tabs,
   theme,
+  tintColor,
+  defaultTintAccent,
   footerContent,
   footerActionLabel,
   roomSelector,
@@ -504,6 +498,7 @@ function BaseCardDialogCardVariant({
   onActiveTabChange,
 }: BaseCardDialogCardProps) {
   const { t } = useI18n();
+  const { accentColor } = useTheme();
   const surface = getThemeSurfaceTokens(theme);
   const dialogSurface = contentSurface ?? getBaseCardDialogSurface(theme);
   const firstTabKey = tabs[0]?.key;
@@ -527,9 +522,13 @@ function BaseCardDialogCardVariant({
     onActiveTabChange?.(nextTab);
   };
 
+  const paletteControlStyle = useMemo(
+    () => getInheritedDialogSectionStyle(theme, tintColor, defaultTintAccent ?? accentColor),
+    [accentColor, defaultTintAccent, theme, tintColor]
+  );
   const widgetRoomSelector = useMemo(
-    () => (roomSelector ? getWidgetRoomSelector(roomSelector, theme) : null),
-    [roomSelector, theme]
+    () => (roomSelector ? getWidgetRoomSelector(roomSelector, theme, paletteControlStyle) : null),
+    [paletteControlStyle, roomSelector, theme]
   );
   const headerRoomSelectorStyle = useMemo<CSSProperties>(
     () => ({
@@ -537,8 +536,9 @@ function BaseCardDialogCardVariant({
       paddingInline: '10px',
       fontSize: '0.75rem',
       lineHeight: '1rem',
+      ...paletteControlStyle,
     }),
-    []
+    [paletteControlStyle]
   );
 
   const resolvedContentClassName = cn(
@@ -617,7 +617,7 @@ function BaseCardDialogCardVariant({
           ) : (
             <CardDialogFooter>
               <Dialog.Close asChild>
-                <Button variant="secondary" size="small">
+                <Button variant="soft" size="small" style={paletteControlStyle}>
                   {footerActionLabel ?? t('common.done')}
                 </Button>
               </Dialog.Close>
@@ -916,12 +916,14 @@ export function BaseCardDialog(props: BaseCardDialogProps) {
 export interface BaseCardDialogWithStateProps
   extends Omit<BaseCardDialogCardProps, 'tabs' | 'variant'> {
   controlsTabContent: ReactNode;
+  controlsTabIcon?: LucideIcon;
   customizeTabContent?: ReactNode;
   extraTabs?: BaseCardDialogTab[];
 }
 
 export function BaseCardDialogWithState({
   controlsTabContent,
+  controlsTabIcon = Sliders,
   customizeTabContent,
   extraTabs = [],
   ...props
@@ -932,7 +934,7 @@ export function BaseCardDialogWithState({
     {
       key: 'controls',
       label: t('common.controls'),
-      icon: Sliders,
+      icon: controlsTabIcon,
       content: controlsTabContent,
     },
     ...(customizeTabContent || props.onTintColorChange

--- a/packages/app/src/components/shared/entity-room-selector.test.tsx
+++ b/packages/app/src/components/shared/entity-room-selector.test.tsx
@@ -1,6 +1,6 @@
 import type { ProviderEntityRoomContext } from '@navet/app/hooks';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { EntityRoomSelector } from './entity-room-selector';
 
 const { updateEntityRoomMock, setRoomOverrideMock, clearRoomOverrideMock } = vi.hoisted(() => ({
@@ -25,6 +25,7 @@ function createRoomContext(areaId: string | null): ProviderEntityRoomContext {
 let mockRoomContext: ProviderEntityRoomContext = {
   ...createRoomContext('bathroom'),
 };
+let mockProviderEntity: { room?: string; roomId?: string } | null = null;
 
 vi.mock('@navet/app/hooks', () => ({
   useI18n: () => ({
@@ -55,6 +56,7 @@ vi.mock('@navet/app/hooks', () => ({
       },
     }),
   useProviderEntityRoomContext: () => mockRoomContext,
+  useProviderEntityModel: () => mockProviderEntity,
 }));
 
 vi.mock('@navet/app/stores/entity-room-overrides-store', () => ({
@@ -74,6 +76,10 @@ vi.mock('@navet/app/services/integration-admin.service', () => ({
 }));
 
 describe('EntityRoomSelector', () => {
+  beforeEach(() => {
+    mockProviderEntity = null;
+  });
+
   it('uses neutral native popup classes for compact selectors', () => {
     mockRoomContext = createRoomContext('bathroom');
     render(<EntityRoomSelector entityId="home_assistant:media_player.bathroom" compact />);
@@ -141,6 +147,25 @@ describe('EntityRoomSelector', () => {
         fallbackRoomName="Bathroom"
       />
     );
+
+    expect(screen.getAllByText('Bathroom')).toHaveLength(2);
+    expect(screen.getByRole('combobox', { name: 'Room' })).toHaveValue('home_assistant:bathroom');
+  });
+
+  it('matches an already-scoped registry room id without double-scoping it', () => {
+    mockRoomContext = createRoomContext('home_assistant:bathroom');
+
+    render(<EntityRoomSelector entityId="home_assistant:media_player.bathroom" compact />);
+
+    expect(screen.getAllByText('Bathroom')).toHaveLength(2);
+    expect(screen.getByRole('combobox', { name: 'Room' })).toHaveValue('home_assistant:bathroom');
+  });
+
+  it('uses the normalized entity room when registry context is unavailable', () => {
+    mockRoomContext = { entry: null, deviceAreaId: null };
+    mockProviderEntity = { room: 'Bathroom', roomId: 'bathroom' };
+
+    render(<EntityRoomSelector entityId="home_assistant:media_player.bathroom" compact />);
 
     expect(screen.getAllByText('Bathroom')).toHaveLength(2);
     expect(screen.getByRole('combobox', { name: 'Room' })).toHaveValue('home_assistant:bathroom');

--- a/packages/app/src/components/shared/entity-room-selector.tsx
+++ b/packages/app/src/components/shared/entity-room-selector.tsx
@@ -4,6 +4,7 @@ import { getThemeSurfaceTokens } from '@navet/app/components/shared/theme/theme-
 import {
   useI18n,
   useIntegrationStore,
+  useProviderEntityModel,
   useProviderEntityRoomContext,
   useTheme,
 } from '@navet/app/hooks';
@@ -18,7 +19,7 @@ import {
 } from '@navet/app/utils/provider-ids';
 import { Loader2 } from 'lucide-react';
 import type { CSSProperties } from 'react';
-import { memo, useMemo, useState } from 'react';
+import { memo, useCallback, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
 interface EntityRoomSelectorProps {
@@ -52,6 +53,7 @@ export const EntityRoomSelector = memo(function EntityRoomSelector({
   const { t } = useI18n();
   const currentProviderId = useIntegrationStore(integrationSelectors.currentProviderId);
   const roomRegistry = useProviderEntityRoomContext(entityId);
+  const providerEntity = useProviderEntityModel(entityId);
   const roomIdsByEntityId = useEntityRoomOverridesStore((state) => state.roomIdsByEntityId);
   const setRoomOverride = useEntityRoomOverridesStore((state) => state.setRoomOverride);
   const clearRoomOverride = useEntityRoomOverridesStore((state) => state.clearRoomOverride);
@@ -77,8 +79,22 @@ export const EntityRoomSelector = memo(function EntityRoomSelector({
   const localRoomOverrideId = roomIdsByEntityId[resolvedEntityId] ?? null;
   const canManageRoom = assignableRooms.length > 0;
   const usesProviderRoomAssignment = roomRegistry.entry != null;
+  const findAssignableRoom = useCallback(
+    (roomId: string | null | undefined) => {
+      if (!roomId) return null;
+      const nativeRoomId = getProviderNativeId(roomId);
+      return (
+        assignableRooms.find(
+          (room) => room.id === roomId || getProviderNativeId(room.id) === nativeRoomId
+        ) ?? null
+      );
+    },
+    [assignableRooms]
+  );
   const fallbackManagedRoom = useMemo(() => {
-    const normalizedFallbackRoomName = fallbackRoomName?.trim().toLowerCase();
+    const normalizedFallbackRoomName = (fallbackRoomName ?? providerEntity?.room)
+      ?.trim()
+      .toLowerCase();
     if (!normalizedFallbackRoomName) {
       return null;
     }
@@ -88,32 +104,29 @@ export const EntityRoomSelector = memo(function EntityRoomSelector({
         (room) => room.name.trim().toLowerCase() === normalizedFallbackRoomName
       ) ?? null
     );
-  }, [assignableRooms, fallbackRoomName]);
+  }, [assignableRooms, fallbackRoomName, providerEntity?.room]);
   const selectedRoomId = useMemo(() => {
     if (localRoomOverrideId) {
-      return localRoomOverrideId;
+      return findAssignableRoom(localRoomOverrideId)?.id ?? localRoomOverrideId;
     }
 
     const entityEntry = roomRegistry.entry;
-    if (!entityEntry) {
-      return fallbackManagedRoom?.id ?? '';
+    if (entityEntry?.area_id) {
+      const registryRoom = findAssignableRoom(entityEntry.area_id);
+      if (registryRoom) return registryRoom.id;
     }
 
-    if (entityEntry.area_id) {
-      return createProviderScopedId(entityProviderId, entityEntry.area_id);
+    if (entityEntry?.device_id && roomRegistry.deviceAreaId) {
+      const deviceRoom = findAssignableRoom(roomRegistry.deviceAreaId);
+      if (deviceRoom) return deviceRoom.id;
     }
 
-    if (!entityEntry.device_id) {
-      return fallbackManagedRoom?.id ?? '';
-    }
-
-    return roomRegistry.deviceAreaId
-      ? createProviderScopedId(entityProviderId, roomRegistry.deviceAreaId)
-      : (fallbackManagedRoom?.id ?? '');
+    return findAssignableRoom(providerEntity?.roomId)?.id ?? fallbackManagedRoom?.id ?? '';
   }, [
-    entityProviderId,
     fallbackManagedRoom?.id,
+    findAssignableRoom,
     localRoomOverrideId,
+    providerEntity?.roomId,
     roomRegistry.deviceAreaId,
     roomRegistry.entry,
   ]);
@@ -121,6 +134,7 @@ export const EntityRoomSelector = memo(function EntityRoomSelector({
     assignableRooms.find((room) => room.id === selectedRoomId)?.name ??
     fallbackManagedRoom?.name ??
     fallbackRoomName?.trim() ??
+    providerEntity?.room?.trim() ??
     t('common.noRoom');
   const baseSelectClassName = compact
     ? `h-9 rounded-xl px-3 py-0 pr-8 text-xs leading-none ${surface.textPrimary}`

--- a/packages/app/src/components/shared/theme/custom-card-tint-surface.ts
+++ b/packages/app/src/components/shared/theme/custom-card-tint-surface.ts
@@ -3,6 +3,8 @@ import type { ThemeType } from '@navet/app/hooks/use-theme';
 import { darkenColor, darkenColorPreserveHue } from '@navet/app/utils/color-utils';
 import type { CSSProperties } from 'react';
 
+export const NEUTRAL_DIALOG_CONTROL_ACCENT = '#6b7280';
+
 function isValidHexColor(value: string | null | undefined): value is string {
   return typeof value === 'string' && /^#[0-9a-fA-F]{6}$/.test(value);
 }

--- a/packages/app/src/features/chores/chore-card-action.test.ts
+++ b/packages/app/src/features/chores/chore-card-action.test.ts
@@ -73,4 +73,30 @@ describe('getChoreCardAction', () => {
       action: { type: 'complete', participantId: 'sam' },
     });
   });
+
+  it('offers Mark done for a missed chore and attributes the late completion', () => {
+    const execute = vi
+      .fn<(action: ChoreWorkspaceAction) => Promise<boolean>>()
+      .mockResolvedValue(true);
+    const action = getChoreCardAction(
+      { ...occurrence, status: 'missed', missedAt: '2026-08-18T08:00:00.000Z' },
+      definition,
+      'all',
+      execute,
+      t
+    );
+
+    expect(action).toMatchObject({
+      label: 'household.actions.complete',
+      kind: 'complete',
+      participantIds: ['alex', 'maya', 'sam'],
+    });
+
+    action?.onSelectParticipant?.('maya');
+    expect(execute).toHaveBeenCalledWith({
+      type: 'occurrence_action',
+      occurrenceId: occurrence.id,
+      action: { type: 'complete', participantId: 'maya' },
+    });
+  });
 });

--- a/packages/app/src/features/chores/chore-card-action.ts
+++ b/packages/app/src/features/chores/chore-card-action.ts
@@ -9,7 +9,7 @@ export function getChoreCardAction(
   execute: (action: ChoreWorkspaceAction) => Promise<boolean>,
   t: TranslateFn
 ): ChoreCardAction | undefined {
-  if (occurrence.status === 'done' || occurrence.status === 'missed') {
+  if (occurrence.status === 'done') {
     return undefined;
   }
 
@@ -52,6 +52,12 @@ export function getChoreCardAction(
     if (occurrence.status === 'awaiting_approval') {
       return buildAction('approve', definition.approval.approverIds);
     }
+    if (occurrence.status === 'missed') {
+      return buildAction(
+        'complete',
+        occurrence.claimedBy ? [occurrence.claimedBy] : occurrence.assigneeIds
+      );
+    }
     if (occurrence.status === 'claimed') {
       return occurrence.claimedBy ? buildAction('complete', [occurrence.claimedBy]) : undefined;
     }
@@ -89,6 +95,8 @@ export function getChoreCardAction(
   }
   if (
     occurrence.status === 'available' ||
+    (occurrence.status === 'missed' &&
+      (!occurrence.claimedBy || occurrence.claimedBy === actionParticipantId)) ||
     (occurrence.status === 'claimed' && occurrence.claimedBy === actionParticipantId)
   ) {
     return {

--- a/packages/app/src/features/chores/components/chore-creation-form-groups.tsx
+++ b/packages/app/src/features/chores/components/chore-creation-form-groups.tsx
@@ -1,14 +1,25 @@
 import { CardDialogSection } from '@navet/app/components/patterns';
 import { Input, Select } from '@navet/app/components/primitives';
 import { getThemeSurfaceTokens } from '@navet/app/components/shared/theme/theme-surface-tokens';
-import { navetTypographyTokens } from '@navet/app/components/system/tokens';
+import { navetIconSizeTokens, navetTypographyTokens } from '@navet/app/components/system/tokens';
 import { cn } from '@navet/app/components/ui/utils';
 import { useI18n, useTheme } from '@navet/app/hooks';
 import type { ChoreAssignmentMode, ChoreParticipant, ChoreSchedule } from '@navet/core/chores';
-import type { ReactNode } from 'react';
+import { ChevronDown, SlidersHorizontal } from 'lucide-react';
+import { Children, isValidElement, type ReactNode } from 'react';
 import { ChoreIconPicker } from './chore-icon-picker';
 
 export type ChoreCreationRepeat = ChoreSchedule['frequency'] | 'biweekly' | 'triweekly';
+export type ChoreCreationSection = 'details' | 'assignment' | 'schedule';
+
+interface ChoreCreationSectionOptionsProps {
+  section: ChoreCreationSection;
+  children: ReactNode;
+}
+
+export function ChoreCreationSectionOptions({ children }: ChoreCreationSectionOptionsProps) {
+  return <>{children}</>;
+}
 
 interface ChoreCreationFormGroupsProps {
   title: string;
@@ -24,6 +35,9 @@ interface ChoreCreationFormGroupsProps {
   endDate: string;
   interval: number;
   excludedDates: string;
+  showTemplates?: boolean;
+  showCustomInterval?: boolean;
+  children?: ReactNode;
   onTitleChange: (value: string) => void;
   onIconChange: (value: string) => void;
   onRoomChange: (value: string) => void;
@@ -37,7 +51,16 @@ interface ChoreCreationFormGroupsProps {
   onExcludedDatesChange: (value: string) => void;
 }
 
-export function ChoreFormGroup({ title, children }: { title: string; children: ReactNode }) {
+export function ChoreFormGroup({
+  title,
+  children,
+  moreOptions,
+}: {
+  title: string;
+  children: ReactNode;
+  moreOptions?: ReactNode;
+}) {
+  const { t } = useI18n();
   const { theme } = useTheme();
   const surface = getThemeSurfaceTokens(theme);
 
@@ -60,6 +83,30 @@ export function ChoreFormGroup({ title, children }: { title: string; children: R
         )}
       >
         {children}
+        {moreOptions ? (
+          <details className={cn('group border-t pt-2 sm:col-span-2', surface.border)}>
+            <summary
+              aria-label={`${t('household.choreDialog.moreOptions')}: ${title}`}
+              className={cn(
+                '-mx-1 flex min-h-10 cursor-pointer list-none items-center gap-2 rounded-xl px-2 py-1.5 text-sm font-semibold select-none focus-visible:outline-2 focus-visible:outline-offset-2 [&::-webkit-details-marker]:hidden',
+                surface.hoverBg,
+                surface.textPrimary
+              )}
+            >
+              <SlidersHorizontal aria-hidden="true" className={navetIconSizeTokens.sm} />
+              <span className="min-w-0 flex-1">{t('household.choreDialog.moreOptions')}</span>
+              <ChevronDown
+                aria-hidden="true"
+                className={cn(
+                  navetIconSizeTokens.sm,
+                  'transition-transform group-open:rotate-180 motion-reduce:transition-none',
+                  surface.textSecondary
+                )}
+              />
+            </summary>
+            <div className="grid gap-4 pt-4 sm:grid-cols-2">{moreOptions}</div>
+          </details>
+        ) : null}
       </div>
     </section>
   );
@@ -79,6 +126,9 @@ export function ChoreCreationFormGroups({
   endDate,
   interval,
   excludedDates,
+  showTemplates = true,
+  showCustomInterval = false,
+  children,
   onTitleChange,
   onIconChange,
   onRoomChange,
@@ -99,36 +149,53 @@ export function ChoreCreationFormGroups({
     [t('household.demo.plants'), 'Sprout'],
     [t('household.demo.bins'), 'Recycle'],
   ] as const;
+  const sectionOptions = (section: ChoreCreationSection) => {
+    for (const child of Children.toArray(children)) {
+      if (
+        isValidElement<ChoreCreationSectionOptionsProps>(child) &&
+        child.type === ChoreCreationSectionOptions &&
+        child.props.section === section
+      ) {
+        return child.props.children;
+      }
+    }
+    return undefined;
+  };
 
   return (
     <div className="grid gap-6">
-      <ChoreFormGroup title={t('household.setup.choreGroupDetails')}>
-        <div className="sm:col-span-2">
-          <p className={cn(navetTypographyTokens.label, surface.textPrimary)}>
-            {t('household.choreDialog.quickStart')}
-          </p>
-          <div className="mt-2 flex flex-wrap gap-2">
-            {templates.map(([templateTitle, templateIcon]) => (
-              <button
-                key={templateTitle}
-                type="button"
-                aria-pressed={title === templateTitle}
-                className={cn(
-                  'min-h-9 rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors focus-visible:outline-2 focus-visible:outline-offset-2',
-                  surface.borderStrong,
-                  title === templateTitle ? surface.iconBg : surface.hoverBg,
-                  surface.textPrimary
-                )}
-                onClick={() => {
-                  onTitleChange(templateTitle);
-                  onIconChange(templateIcon);
-                }}
-              >
-                {templateTitle}
-              </button>
-            ))}
+      <ChoreFormGroup
+        title={t('household.setup.choreGroupDetails')}
+        moreOptions={sectionOptions('details')}
+      >
+        {showTemplates ? (
+          <div className="sm:col-span-2">
+            <p className={cn(navetTypographyTokens.label, surface.textPrimary)}>
+              {t('household.choreDialog.quickStart')}
+            </p>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {templates.map(([templateTitle, templateIcon]) => (
+                <button
+                  key={templateTitle}
+                  type="button"
+                  aria-pressed={title === templateTitle}
+                  className={cn(
+                    'min-h-9 rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors focus-visible:outline-2 focus-visible:outline-offset-2',
+                    surface.borderStrong,
+                    title === templateTitle ? surface.iconBg : surface.hoverBg,
+                    surface.textPrimary
+                  )}
+                  onClick={() => {
+                    onTitleChange(templateTitle);
+                    onIconChange(templateIcon);
+                  }}
+                >
+                  {templateTitle}
+                </button>
+              ))}
+            </div>
           </div>
-        </div>
+        ) : null}
         <CardDialogSection className="mb-0" label={t('household.choreDialog.name')}>
           <Input
             aria-label={t('household.choreDialog.name')}
@@ -159,7 +226,10 @@ export function ChoreCreationFormGroups({
         </CardDialogSection>
       </ChoreFormGroup>
 
-      <ChoreFormGroup title={t('household.setup.choreGroupAssignment')}>
+      <ChoreFormGroup
+        title={t('household.setup.choreGroupAssignment')}
+        moreOptions={sectionOptions('assignment')}
+      >
         <CardDialogSection className="mb-0" label={t('household.choreDialog.assignment')}>
           <Select
             aria-label={t('household.choreDialog.assignment')}
@@ -188,7 +258,10 @@ export function ChoreCreationFormGroups({
         </CardDialogSection>
       </ChoreFormGroup>
 
-      <ChoreFormGroup title={t('household.setup.choreGroupSchedule')}>
+      <ChoreFormGroup
+        title={t('household.setup.choreGroupSchedule')}
+        moreOptions={sectionOptions('schedule')}
+      >
         <CardDialogSection className="mb-0" label={t('household.choreDialog.schedule')}>
           <Select
             aria-label={t('household.choreDialog.schedule')}
@@ -239,6 +312,17 @@ export function ChoreCreationFormGroups({
           >
             <Input
               aria-label={t('household.setup.scheduleAfterCompletionLabel')}
+              min={1}
+              type="number"
+              value={interval}
+              onChange={(event) => onIntervalChange(Math.max(1, Number(event.target.value)))}
+            />
+          </CardDialogSection>
+        ) : null}
+        {showCustomInterval && (repeat === 'daily' || repeat === 'weekly') ? (
+          <CardDialogSection className="mb-0" label={t('household.choreDialog.repeatEvery')}>
+            <Input
+              aria-label={t('household.choreDialog.repeatEvery')}
               min={1}
               type="number"
               value={interval}

--- a/packages/app/src/features/chores/components/chore-management-views.tsx
+++ b/packages/app/src/features/chores/components/chore-management-views.tsx
@@ -363,7 +363,7 @@ export function AllChoresView({
                         </span>
                       </span>
                     ) : null}
-                    {presentation?.points ? (
+                    {experience.gamificationMode !== 'off' && presentation?.points ? (
                       <ChorePointsToken points={presentation.points} />
                     ) : null}
                   </>

--- a/packages/app/src/features/chores/components/chore-setup-dialogs.stories.tsx
+++ b/packages/app/src/features/chores/components/chore-setup-dialogs.stories.tsx
@@ -70,7 +70,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'Add and Edit Chore share the same four-section sidebar and advanced controls. Each section uses the grouped surface language from onboarding, while onboarding keeps its shorter inline creation flow.',
+          'Add and Edit Chore use the same continuous three-part flow as onboarding, with a compact identity preview and contextual More options disclosures inside each section.',
       },
     },
   },
@@ -81,34 +81,46 @@ type Story = StoryObj<typeof meta>;
 
 export const DesktopDetails: Story = {};
 
-export const MobileGroupedStepper: Story = {
+export const MobileContinuousEditor: Story = {
   parameters: { viewport: { defaultViewport: 'mobile1' } },
   play: async ({ canvasElement }) => {
     saveChore.mockClear();
     const dialog = within(canvasElement.ownerDocument.body).getByRole('dialog', {
       name: 'Add a chore',
     });
-    await expect(within(dialog).getByText('Step 1 of 4')).toBeInTheDocument();
-    await expect(within(dialog).getByRole('heading', { name: 'The chore' })).toBeInTheDocument();
-    await expect(within(dialog).getByRole('button', { name: 'Assignment' })).toBeDisabled();
+    await expect(
+      within(dialog).getAllByRole('heading', { name: 'The chore' })[0]
+    ).toBeInTheDocument();
+    await expect(within(dialog).getByRole('heading', { name: 'Who does it' })).toBeInTheDocument();
+    await expect(
+      within(dialog).getByRole('heading', { name: 'When it repeats' })
+    ).toBeInTheDocument();
     await expect(within(dialog).getByLabelText('Chore name')).toHaveValue('');
     await expect(within(dialog).getByLabelText('Room')).toBeInTheDocument();
+    await expect(within(dialog).getAllByLabelText('Repeat every')).toHaveLength(1);
     await userEvent.type(within(dialog).getByLabelText('Chore name'), 'Water the plants');
-    await userEvent.click(within(dialog).getByRole('button', { name: 'Next' }));
-    await expect(within(dialog).getByText('Step 2 of 4')).toBeInTheDocument();
-    await expect(within(dialog).getByRole('heading', { name: 'Who does it' })).toBeInTheDocument();
+    await expect(dialog.querySelector('[aria-live="polite"]')).toHaveTextContent(
+      'Water the plants'
+    );
     await userEvent.selectOptions(within(dialog).getByLabelText('Assignment'), 'everyone');
+    await expect(within(dialog).getByLabelText('Person')).toBeDisabled();
+    await expect(within(dialog).getAllByText('More options')).toHaveLength(3);
+    await expect(within(dialog).getByLabelText('Instructions')).not.toBeVisible();
+    await userEvent.click(within(dialog).getByLabelText('More options: The chore'));
+    await expect(within(dialog).getByLabelText('Instructions')).toBeVisible();
+    await expect(within(dialog).getByLabelText('Require approval')).not.toBeVisible();
   },
 };
 
-export const DesktopGroupedSidebarCreation: Story = {
+export const DesktopContinuousCreation: Story = {
   play: async ({ canvasElement }) => {
     saveChore.mockClear();
     const dialog = within(canvasElement.ownerDocument.body).getByRole('dialog', {
       name: 'Add a chore',
     });
-    await expect(within(dialog).getByText('Step 1 of 4')).toBeInTheDocument();
-    await expect(within(dialog).getByRole('heading', { name: 'The chore' })).toBeInTheDocument();
+    await expect(
+      within(dialog).getAllByRole('heading', { name: 'The chore' })[0]
+    ).toBeInTheDocument();
     const iconSearch = within(dialog).getByLabelText('Paste Lucide icon name');
     await userEvent.clear(iconSearch);
     await userEvent.type(iconSearch, 'Telescope');
@@ -118,10 +130,8 @@ export const DesktopGroupedSidebarCreation: Story = {
     await expect(within(dialog).getByRole('img', { name: 'Telescope' })).toBeInTheDocument();
     await expect(within(dialog).getByRole('alert')).toHaveTextContent('Icon name not found');
     await userEvent.type(within(dialog).getByLabelText('Chore name'), 'Clean the hallway');
-    await userEvent.click(within(dialog).getByRole('button', { name: 'Next' }));
     await expect(within(dialog).getByRole('heading', { name: 'Who does it' })).toBeInTheDocument();
     await userEvent.selectOptions(within(dialog).getByLabelText('Assignment'), 'everyone');
-    await userEvent.click(within(dialog).getByRole('button', { name: 'Next' }));
     await expect(
       within(dialog).getByRole('heading', { name: 'When it repeats' })
     ).toBeInTheDocument();
@@ -131,16 +141,17 @@ export const DesktopGroupedSidebarCreation: Story = {
     await expect(repeatSelect).toHaveValue('biweekly');
     await userEvent.selectOptions(repeatSelect, 'triweekly');
     await expect(repeatSelect).toHaveValue('triweekly');
-    await expect(within(dialog).getByLabelText('Repeat every')).toHaveValue(3);
     fireEvent.change(within(dialog).getByLabelText('Start date'), {
       target: { value: '2026-12-07' },
     });
     await userEvent.type(within(dialog).getByLabelText('End date'), '2026-12-31');
     await userEvent.type(within(dialog).getByLabelText('Dates to skip'), '2026-12-24');
-    await userEvent.click(within(dialog).getByRole('button', { name: 'Next' }));
-    await expect(
-      within(dialog).getByRole('heading', { level: 2, name: 'More options' })
-    ).toBeInTheDocument();
+    await userEvent.click(within(dialog).getByLabelText('More options: The chore'));
+    await userEvent.click(within(dialog).getByLabelText('More options: When it repeats'));
+    await expect(within(dialog).queryByLabelText('Repeat every')).toBeNull();
+    await expect(dialog.querySelectorAll('input[type="color"]')).toHaveLength(1);
+    await expect(within(dialog).getByLabelText('Instructions')).toBeInTheDocument();
+    await expect(within(dialog).getByLabelText('When missed')).toBeInTheDocument();
     await userEvent.click(within(dialog).getByRole('button', { name: 'Add chore' }));
     await expect(saveChore).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -163,6 +174,7 @@ export const EditColorOverride: Story = {
     const dialog = within(canvasElement.ownerDocument.body).getByRole('dialog', {
       name: 'Edit chore',
     });
+    await expect(within(dialog).queryByText('Start with a template')).toBeNull();
     const colorInput = dialog.querySelector('input[type="color"]');
     await expect(colorInput).not.toBeNull();
     fireEvent.change(colorInput as HTMLInputElement, { target: { value: '#2563eb' } });
@@ -172,6 +184,10 @@ export const EditColorOverride: Story = {
       expect.objectContaining({ color: '#2563eb' })
     );
   },
+};
+
+export const LightTheme: Story = {
+  globals: { theme: 'light' },
 };
 
 export const PersonStepperCreation: Story = {

--- a/packages/app/src/features/chores/components/chore-setup-dialogs.tsx
+++ b/packages/app/src/features/chores/components/chore-setup-dialogs.tsx
@@ -4,7 +4,6 @@ import {
   CardDialogHeader,
   CardDialogSection,
   CardDialogTabList,
-  NavigationWorkspace,
 } from '@navet/app/components/patterns';
 import {
   BaseCardDialog,
@@ -31,18 +30,15 @@ import type {
   ChoreParticipant,
   ChoreSchedule,
 } from '@navet/core/chores';
-import {
-  CalendarClock,
-  ChevronDown,
-  ListChecks,
-  SlidersHorizontal,
-  UserRound,
-  X,
-} from 'lucide-react';
+import { ChevronDown, RotateCcw, SlidersHorizontal, UserRound, X } from 'lucide-react';
 import { type FormEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { resolveChoreColorPalette } from '../chore-color-palette';
-import { ChoreFormGroup } from './chore-creation-form-groups';
-import { ChoreIconPicker } from './chore-icon-picker';
+import {
+  ChoreCreationFormGroups,
+  type ChoreCreationRepeat,
+  ChoreCreationSectionOptions,
+} from './chore-creation-form-groups';
+import { resolveChoreIconComponent } from './chore-icon';
 import { ChoreProfileAppearanceEditor } from './chore-profile-appearance-editor';
 
 function localDateKey(date = new Date()) {
@@ -595,7 +591,7 @@ export function AddChoreDialog({
   ) => Promise<boolean>;
 }) {
   const { t } = useI18n();
-  const { theme, accentColor } = useTheme();
+  const { theme } = useTheme();
   const surface = getThemeSurfaceTokens(theme);
   const [title, setTitle] = useState('');
   const [choreIcon, setChoreIcon] = useState('ListChecks');
@@ -629,10 +625,6 @@ export function AddChoreDialog({
   const [remindBeforeMinutes, setRemindBeforeMinutes] = useState(30);
   const [overdueEveryMinutes, setOverdueEveryMinutes] = useState(60);
   const [saving, setSaving] = useState(false);
-  const [editorSection, setEditorSection] = useState<
-    'details' | 'assignment' | 'schedule' | 'options'
-  >('details');
-  const [furthestEditorSection, setFurthestEditorSection] = useState(0);
   const completers = useMemo(
     () => participants.filter((participant) => participant.capabilities.includes('complete')),
     [participants]
@@ -655,8 +647,6 @@ export function AddChoreDialog({
 
   useEffect(() => {
     if (isOpen) {
-      setEditorSection('details');
-      setFurthestEditorSection(0);
       setTitle(definition?.title ?? '');
       setChoreIcon(presentation?.icon ?? 'ListChecks');
       setChoreColor(presentation?.color ?? '');
@@ -751,8 +741,6 @@ export function AddChoreDialog({
       setRemindBeforeMinutes(30);
       setOverdueEveryMinutes(60);
       setSaving(false);
-      setEditorSection('details');
-      setFurthestEditorSection(0);
     }
   }, [completers, definition, isOpen, presentation]);
 
@@ -760,14 +748,7 @@ export function AddChoreDialog({
     event.preventDefault();
     const normalizedTitle = title.trim();
     if (!normalizedTitle || completers.length === 0) return;
-    const activeEditorIndex = editorSections.findIndex((section) => section.id === editorSection);
-    if (editorSection === 'assignment' && assignmentMode === 'person' && !participantId) return;
-    if (!definition && activeEditorIndex < editorSections.length - 1) {
-      const nextIndex = activeEditorIndex + 1;
-      setEditorSection(editorSections[nextIndex].id);
-      setFurthestEditorSection((current) => Math.max(current, nextIndex));
-      return;
-    }
+    if (assignmentMode === 'person' && !participantId) return;
     const timestamp = new Date().toISOString();
     const startDate = scheduleStartDate || localDateKey();
     const timeZone =
@@ -922,36 +903,10 @@ export function AddChoreDialog({
   const dialogDescription = definition
     ? t('household.choreDialog.editDescription')
     : t('household.choreDialog.description');
-  const editorSections = [
-    {
-      id: 'details' as const,
-      label: t('household.choreDialog.name'),
-      icon: ListChecks,
-    },
-    {
-      id: 'assignment' as const,
-      label: t('household.choreDialog.assignment'),
-      icon: UserRound,
-    },
-    {
-      id: 'schedule' as const,
-      label: t('household.choreDialog.schedule'),
-      icon: CalendarClock,
-    },
-    {
-      id: 'options' as const,
-      label: t('household.choreDialog.moreOptions'),
-      icon: SlidersHorizontal,
-    },
-  ];
-  const activeSection =
-    editorSections.find((section) => section.id === editorSection) ?? editorSections[0];
-  const activeEditorIndex = editorSections.findIndex((section) => section.id === editorSection);
-  const isCreationStepper = !definition;
-  const canContinue =
+  const canSave =
     title.trim().length > 0 &&
     completers.length > 0 &&
-    (editorSection !== 'assignment' || assignmentMode !== 'person' || participantId.length > 0);
+    (assignmentMode !== 'person' || participantId.length > 0);
   const repeatValue =
     frequency === 'weekly' && scheduleInterval === 2
       ? 'biweekly'
@@ -959,12 +914,7 @@ export function AddChoreDialog({
         ? 'triweekly'
         : frequency;
 
-  const selectEditorSection = (index: number) => {
-    if (isCreationStepper && index > furthestEditorSection) return;
-    setEditorSection(editorSections[index].id);
-  };
-
-  const selectRepeat = (value: ChoreSchedule['frequency'] | 'biweekly' | 'triweekly') => {
+  const selectRepeat = (value: ChoreCreationRepeat) => {
     if (value === 'biweekly' || value === 'triweekly') {
       setFrequency('weekly');
       setScheduleInterval(value === 'biweekly' ? 2 : 3);
@@ -974,6 +924,24 @@ export function AddChoreDialog({
     setFrequency(value);
     setScheduleInterval(1);
   };
+  const previewColor =
+    choreColor || resolveChoreColorPalette(definition?.id ?? (title.trim() || 'new-chore')).primary;
+  const PreviewIcon = resolveChoreIconComponent(choreIcon);
+  const selectedRoom = roomChoices.find((room) => room.canonicalId === roomLabel);
+  const repeatLabel =
+    repeatValue === 'once'
+      ? t('household.schedule.once')
+      : repeatValue === 'daily'
+        ? t('household.schedule.daily')
+        : repeatValue === 'weekly'
+          ? t('household.schedule.weekly')
+          : repeatValue === 'biweekly'
+            ? t('household.schedule.biweekly')
+            : repeatValue === 'triweekly'
+              ? t('household.schedule.triweekly')
+              : repeatValue === 'monthly'
+                ? t('household.schedule.monthly')
+                : t('household.schedule.afterCompletion');
 
   return (
     <BaseCardDialog
@@ -984,592 +952,399 @@ export function AddChoreDialog({
       description={dialogDescription}
       theme={theme}
       contentClassName={cn(
-        'md:left-1/2 md:right-auto md:w-[calc(100%-4rem)] md:max-w-[1200px] md:-translate-x-1/2',
+        'md:left-1/2 md:right-auto md:w-[calc(100%-4rem)] md:max-w-[900px] md:-translate-x-1/2',
         'backdrop-blur-2xl',
         surface.shellPanel,
         surface.border
       )}
       shellBodyClassName="h-full min-h-0"
     >
-      <form className="h-full min-h-0" onSubmit={submit}>
-        <NavigationWorkspace.Frame
-          aria-label={dialogTitle}
-          className="h-full min-h-0 rounded-none border-0 bg-transparent shadow-none"
+      <form className="flex h-full min-h-0 flex-col" onSubmit={submit}>
+        <header
+          className={cn(
+            'flex items-start justify-between gap-4 border-b px-4 py-4 sm:px-6',
+            surface.border
+          )}
         >
-          <NavigationWorkspace.Header className="flex items-start justify-between gap-4 px-4 py-4 sm:px-5">
-            <div className="min-w-0">
-              <h1 className={cn(navetTypographyTokens.pageHeading, surface.textPrimary)}>
-                {dialogTitle}
-              </h1>
-              <p className={cn('mt-1', navetTypographyTokens.body, surface.textSecondary)}>
-                {dialogDescription}
-              </p>
-            </div>
-            <IconButton
-              variant="ghost"
-              label={t('common.close')}
-              icon={<X aria-hidden="true" className={navetIconSizeTokens.sm} />}
-              className={cn('min-h-10 min-w-10 shrink-0', surface.subtleBg, surface.hoverBg)}
-              onClick={() => onOpenChange(false)}
-            />
-          </NavigationWorkspace.Header>
-          <NavigationWorkspace.Body className="grid-rows-[auto_minmax(0,1fr)] md:grid-cols-[16rem_minmax(0,1fr)] md:grid-rows-1">
-            <NavigationWorkspace.Sidebar className="scrollbar-hide overflow-x-auto border-r-0 border-b p-3 md:overflow-y-auto md:border-r md:border-b-0 md:p-4">
-              <nav
-                className="flex min-w-max gap-1 md:grid md:min-w-0"
-                aria-label={isCreationStepper ? t('household.setup.progressLabel') : dialogTitle}
+          <div className="min-w-0">
+            <h1 className={cn(navetTypographyTokens.pageHeading, surface.textPrimary)}>
+              {dialogTitle}
+            </h1>
+            <p className={cn('mt-1 max-w-2xl', navetTypographyTokens.body, surface.textSecondary)}>
+              {dialogDescription}
+            </p>
+          </div>
+          <IconButton
+            variant="ghost"
+            label={t('common.close')}
+            icon={<X aria-hidden="true" className={navetIconSizeTokens.sm} />}
+            className={cn('min-h-10 min-w-10 shrink-0', surface.subtleBg, surface.hoverBg)}
+            onClick={() => onOpenChange(false)}
+          />
+        </header>
+
+        <div className="scrollbar-hide min-h-0 flex-1 overflow-y-auto overscroll-contain touch-pan-y">
+          <main className="mx-auto w-full max-w-[50rem] px-4 py-6 sm:px-7 sm:py-8">
+            <div
+              className={cn(
+                'mb-7 flex min-w-0 items-center gap-3 rounded-[24px] border p-3.5 sm:p-4',
+                surface.subtleBg,
+                surface.borderStrong
+              )}
+              aria-live="polite"
+            >
+              <span
+                className="flex h-11 w-11 shrink-0 items-center justify-center rounded-[18px] border"
+                style={{
+                  backgroundColor: `${previewColor}18`,
+                  borderColor: `${previewColor}45`,
+                  color: previewColor,
+                }}
               >
-                {editorSections.map((section, index) => {
-                  const Icon = section.icon;
-                  const active = section.id === editorSection;
-                  const disabled = isCreationStepper && index > furthestEditorSection;
-                  return (
-                    <NavigationWorkspace.Item
-                      key={section.id}
-                      active={active}
-                      accentColor={accentColor}
-                      className="w-[10.5rem] md:w-auto"
-                    >
-                      <NavigationWorkspace.ItemButton
-                        aria-current={active ? (isCreationStepper ? 'step' : 'page') : undefined}
-                        disabled={disabled}
-                        className="disabled:cursor-not-allowed disabled:opacity-50"
-                        onClick={() => selectEditorSection(index)}
-                      >
-                        <NavigationWorkspace.ItemIcon>
-                          <Icon className={navetIconSizeTokens.sm} />
-                        </NavigationWorkspace.ItemIcon>
-                        <NavigationWorkspace.ItemText title={section.label} />
-                      </NavigationWorkspace.ItemButton>
-                    </NavigationWorkspace.Item>
-                  );
-                })}
-              </nav>
-            </NavigationWorkspace.Sidebar>
-            <NavigationWorkspace.Content>
-              <NavigationWorkspace.ScrollArea className="scrollbar-hide">
-                <div className="flex min-h-full flex-col">
-                  <div className="w-full flex-1 px-4 py-6 sm:px-7 sm:py-8 lg:px-10">
-                    {isCreationStepper ? (
-                      <p className={cn('mb-2 text-xs font-semibold', surface.textSecondary)}>
-                        {t('household.setup.stepCount', {
-                          current: activeEditorIndex + 1,
-                          total: editorSections.length,
-                        })}
-                      </p>
-                    ) : null}
-                    <h2 className={cn(navetTypographyTokens.pageHeading, surface.textPrimary)}>
-                      {activeSection.label}
-                    </h2>
-                    <p
-                      className={cn(
-                        'mt-2 max-w-xl',
-                        navetTypographyTokens.body,
-                        surface.textSecondary
-                      )}
-                    >
-                      {dialogDescription}
-                    </p>
+                <PreviewIcon aria-hidden="true" className={navetIconSizeTokens.md} />
+              </span>
+              <div className="min-w-0 flex-1">
+                <p className={cn('truncate text-sm font-semibold', surface.textPrimary)}>
+                  {title.trim() || t('household.choreDialog.namePlaceholder')}
+                </p>
+                <p className={cn('mt-0.5 truncate text-xs', surface.textSecondary)}>
+                  {selectedRoom?.label ?? t('household.choreDialog.noRoom')}
+                  <span aria-hidden="true"> · </span>
+                  {repeatLabel}
+                  <span aria-hidden="true"> · </span>
+                  {time}
+                </p>
+              </div>
+              <ColorInputSwatch
+                mode="picker"
+                size="medium"
+                value={previewColor}
+                visual={choreColor ? 'color' : 'rainbow'}
+                selected={Boolean(choreColor)}
+                ariaLabel={t('widgets.customCard.colorPicker')}
+                onChange={setChoreColor}
+              />
+              {choreColor ? (
+                <IconButton
+                  variant="ghost"
+                  label={t('common.reset')}
+                  icon={<RotateCcw aria-hidden="true" className={navetIconSizeTokens.sm} />}
+                  className="min-h-10 min-w-10 shrink-0"
+                  onClick={() => setChoreColor('')}
+                />
+              ) : null}
+            </div>
 
-                    {editorSection === 'details' ? (
-                      <div className="mt-7">
-                        <ChoreFormGroup title={t('household.setup.choreGroupDetails')}>
-                          <CardDialogSection
-                            className="sm:col-span-2"
-                            label={t('household.choreDialog.name')}
-                          >
-                            <Input
-                              autoFocus
-                              aria-label={t('household.choreDialog.name')}
-                              autoComplete="off"
-                              name="chore-name"
-                              value={title}
-                              placeholder={t('household.choreDialog.namePlaceholder')}
-                              onChange={(event) => setTitle(event.target.value)}
-                            />
-                          </CardDialogSection>
-                          <CardDialogSection
-                            className="sm:col-span-2"
-                            label={t('household.personDialog.avatarModeIcon')}
-                          >
-                            <ChoreIconPicker value={choreIcon} onChange={setChoreIcon} />
-                          </CardDialogSection>
-                          <CardDialogSection label={t('widgets.customCard.color')}>
-                            <div className="flex min-h-10 items-center gap-2">
-                              <ColorInputSwatch
-                                mode="picker"
-                                size="medium"
-                                value={
-                                  choreColor ||
-                                  resolveChoreColorPalette(
-                                    definition?.id ?? (title.trim() || 'new-chore')
-                                  ).primary
-                                }
-                                visual={choreColor ? 'color' : 'rainbow'}
-                                selected={Boolean(choreColor)}
-                                ariaLabel={t('widgets.customCard.colorPicker')}
-                                onChange={setChoreColor}
-                              />
-                              {choreColor ? (
-                                <Button
-                                  type="button"
-                                  size="compact"
-                                  variant="ghost"
-                                  onClick={() => setChoreColor('')}
-                                >
-                                  {t('common.reset')}
-                                </Button>
-                              ) : null}
-                            </div>
-                          </CardDialogSection>
-                          <CardDialogSection
-                            className="sm:col-span-2"
-                            label={t('household.choreDialog.instructions')}
-                          >
-                            <Textarea
-                              aria-label={t('household.choreDialog.instructions')}
-                              value={description}
-                              onChange={(event) => setDescription(event.target.value)}
-                            />
-                          </CardDialogSection>
-                          <CardDialogSection label={t('household.choreDialog.room')}>
-                            <Select
-                              aria-label={t('household.choreDialog.room')}
-                              value={roomLabel}
-                              onChange={(event) => setRoomLabel(event.target.value)}
-                            >
-                              <option value="">{t('household.choreDialog.noRoom')}</option>
-                              {roomChoices.map((room) => (
-                                <option key={room.canonicalId} value={room.canonicalId}>
-                                  {room.label}
-                                </option>
-                              ))}
-                            </Select>
-                          </CardDialogSection>
-                          <CardDialogSection label={t('household.choreDialog.estimatedTime')}>
-                            <Input
-                              aria-label={t('household.choreDialog.estimatedTime')}
-                              min={0}
-                              max={1440}
-                              type="number"
-                              value={estimatedMinutes}
-                              onChange={(event) => setEstimatedMinutes(Number(event.target.value))}
-                            />
-                          </CardDialogSection>
-                          <CardDialogSection label={t('household.choreDialog.points')}>
-                            <Input
-                              aria-label={t('household.choreDialog.points')}
-                              min={0}
-                              max={10000}
-                              type="number"
-                              value={points}
-                              onChange={(event) => setPoints(Number(event.target.value))}
-                            />
-                          </CardDialogSection>
-                          <CardDialogSection label={t('household.choreDialog.childTitle')}>
-                            <Input
-                              aria-label={t('household.choreDialog.childTitle')}
-                              value={childTitle}
-                              onChange={(event) => setChildTitle(event.target.value)}
-                            />
-                          </CardDialogSection>
-                        </ChoreFormGroup>
-                      </div>
-                    ) : null}
-
-                    {editorSection === 'assignment' ? (
-                      <div className="mt-7">
-                        <ChoreFormGroup title={t('household.setup.choreGroupAssignment')}>
-                          <CardDialogSection label={t('household.choreDialog.assignment')}>
-                            <Select
-                              aria-label={t('household.choreDialog.assignment')}
-                              name="chore-assignment"
-                              value={assignmentMode}
-                              onChange={(event) =>
-                                setAssignmentMode(event.target.value as ChoreAssignmentMode)
-                              }
-                            >
-                              <option value="person">{t('household.assignment.person')}</option>
-                              <option value="anyone">{t('household.assignment.anyone')}</option>
-                              <option value="everyone">{t('household.assignment.everyone')}</option>
-                              <option value="rotation">{t('household.assignment.rotation')}</option>
-                            </Select>
-                          </CardDialogSection>
-                          <CardDialogSection label={t('household.choreDialog.person')}>
-                            <Select
-                              aria-label={t('household.choreDialog.person')}
-                              value={participantId}
-                              disabled={assignmentMode !== 'person'}
-                              name="chore-person"
-                              onChange={(event) => setParticipantId(event.target.value)}
-                            >
-                              {completers.map((participant) => (
-                                <option key={participant.id} value={participant.id}>
-                                  {participant.displayName}
-                                </option>
-                              ))}
-                            </Select>
-                          </CardDialogSection>
-                          <div
-                            className={cn(
-                              'flex min-h-12 items-center justify-between gap-4 rounded-2xl border px-4 sm:col-span-2',
-                              surface.borderStrong,
-                              surface.subtleBg,
-                              surface.textPrimary
-                            )}
-                          >
-                            <span className="text-sm font-medium">
-                              {t('household.choreDialog.approval')}
-                            </span>
-                            <Switch
-                              aria-label={t('household.choreDialog.approval')}
-                              checked={approvalRequired}
-                              size="compact"
-                              disabled={approverIds.length === 0}
-                              onCheckedChange={setApprovalRequired}
-                            />
-                          </div>
-                          {assignmentMode === 'rotation' ? (
-                            <>
-                              <CardDialogSection label={t('household.choreDialog.rotationReset')}>
-                                <Select
-                                  aria-label={t('household.choreDialog.rotationReset')}
-                                  value={rotationReset}
-                                  onChange={(event) =>
-                                    setRotationReset(
-                                      event.target.value as 'never' | 'weekly' | 'monthly'
-                                    )
-                                  }
-                                >
-                                  <option value="never">
-                                    {t('household.choreDialog.rotationNever')}
-                                  </option>
-                                  <option value="weekly">{t('household.schedule.weekly')}</option>
-                                  <option value="monthly">{t('household.schedule.monthly')}</option>
-                                </Select>
-                              </CardDialogSection>
-                              <CardDialogSection label={t('household.choreDialog.rotationOffset')}>
-                                <Input
-                                  aria-label={t('household.choreDialog.rotationOffset')}
-                                  min={0}
-                                  type="number"
-                                  value={rotationOffset}
-                                  onChange={(event) =>
-                                    setRotationOffset(Number(event.target.value))
-                                  }
-                                />
-                              </CardDialogSection>
-                            </>
-                          ) : null}
-                          {assignmentMode === 'rotation' || assignmentMode === 'everyone'
-                            ? completers.map((participant) => (
-                                <CardDialogSection
-                                  key={participant.id}
-                                  label={t('household.choreDialog.personTimes', {
-                                    name: participant.displayName,
-                                  })}
-                                >
-                                  <Input
-                                    aria-label={t('household.choreDialog.personTimes', {
-                                      name: participant.displayName,
-                                    })}
-                                    placeholder="08:00, 20:00"
-                                    value={participantTimes[participant.id] ?? ''}
-                                    onChange={(event) =>
-                                      setParticipantTimes((current) => ({
-                                        ...current,
-                                        [participant.id]: event.target.value,
-                                      }))
-                                    }
-                                  />
-                                </CardDialogSection>
-                              ))
-                            : null}
-                          <div
-                            className={cn(
-                              'flex min-h-12 items-center justify-between gap-4 rounded-2xl border px-4 sm:col-span-2',
-                              surface.borderStrong,
-                              surface.subtleBg,
-                              surface.textPrimary
-                            )}
-                          >
-                            <span className="text-sm font-medium">
-                              {t('household.choreDialog.claimRequired')}
-                            </span>
-                            <Switch
-                              aria-label={t('household.choreDialog.claimRequired')}
-                              checked={claimRequired}
-                              size="compact"
-                              onCheckedChange={setClaimRequired}
-                            />
-                          </div>
-                          {claimRequired ? (
-                            <CardDialogSection label={t('household.choreDialog.claimExpiry')}>
-                              <Input
-                                aria-label={t('household.choreDialog.claimExpiry')}
-                                min={1}
-                                type="number"
-                                value={claimExpiryMinutes}
-                                onChange={(event) =>
-                                  setClaimExpiryMinutes(Number(event.target.value))
-                                }
-                              />
-                            </CardDialogSection>
-                          ) : null}
-                        </ChoreFormGroup>
-                      </div>
-                    ) : null}
-
-                    {editorSection === 'schedule' ? (
-                      <div className="mt-7">
-                        <ChoreFormGroup title={t('household.setup.choreGroupSchedule')}>
-                          <CardDialogSection label={t('household.choreDialog.schedule')}>
-                            <Select
-                              aria-label={t('household.choreDialog.schedule')}
-                              name="chore-schedule"
-                              value={repeatValue}
-                              onChange={(event) =>
-                                selectRepeat(
-                                  event.target.value as
-                                    | ChoreSchedule['frequency']
-                                    | 'biweekly'
-                                    | 'triweekly'
-                                )
-                              }
-                            >
-                              <option value="once">{t('household.schedule.once')}</option>
-                              <option value="daily">{t('household.schedule.daily')}</option>
-                              <option value="weekly">{t('household.schedule.weekly')}</option>
-                              <option value="biweekly">{t('household.schedule.biweekly')}</option>
-                              <option value="triweekly">{t('household.schedule.triweekly')}</option>
-                              <option value="monthly">{t('household.schedule.monthly')}</option>
-                              <option value="after_completion">
-                                {t('household.schedule.afterCompletion')}
-                              </option>
-                            </Select>
-                          </CardDialogSection>
-                          <CardDialogSection label={t('household.choreDialog.time')}>
-                            <Input
-                              aria-label={t('household.choreDialog.time')}
-                              name="chore-time"
-                              type="time"
-                              value={time}
-                              onChange={(event) => setTime(event.target.value)}
-                            />
-                          </CardDialogSection>
-                          <CardDialogSection label={t('household.choreDialog.startDate')}>
-                            <Input
-                              aria-label={t('household.choreDialog.startDate')}
-                              type="date"
-                              value={scheduleStartDate}
-                              onChange={(event) => setScheduleStartDate(event.target.value)}
-                            />
-                          </CardDialogSection>
-                          {frequency !== 'once' ? (
-                            <CardDialogSection label={t('household.choreDialog.endDate')}>
-                              <Input
-                                aria-label={t('household.choreDialog.endDate')}
-                                type="date"
-                                value={scheduleEndDate}
-                                onChange={(event) => setScheduleEndDate(event.target.value)}
-                              />
-                            </CardDialogSection>
-                          ) : null}
-                          {frequency === 'daily' ||
-                          frequency === 'weekly' ||
-                          frequency === 'after_completion' ? (
-                            <CardDialogSection label={t('household.choreDialog.repeatEvery')}>
-                              <Input
-                                aria-label={t('household.choreDialog.repeatEvery')}
-                                min={1}
-                                type="number"
-                                value={scheduleInterval}
-                                onChange={(event) =>
-                                  setScheduleInterval(Number(event.target.value))
-                                }
-                              />
-                            </CardDialogSection>
-                          ) : null}
-                          {frequency === 'daily' || frequency === 'weekly' ? (
-                            <CardDialogSection
-                              className="sm:col-span-2"
-                              label={t('household.choreDialog.weekdays')}
-                            >
-                              <div className="flex flex-wrap gap-1.5">
-                                {Array.from({ length: 7 }, (_, day) => {
-                                  const selected = weeklyDays.includes(day);
-                                  const label = new Intl.DateTimeFormat(undefined, {
-                                    weekday: 'short',
-                                  }).format(new Date(Date.UTC(2026, 7, 2 + day)));
-                                  return (
-                                    <Button
-                                      key={day}
-                                      type="button"
-                                      size="compact"
-                                      variant={selected ? 'secondary' : 'ghost'}
-                                      className="min-h-9 min-w-9 px-2"
-                                      aria-pressed={selected}
-                                      onClick={() =>
-                                        setWeeklyDays((current) =>
-                                          selected
-                                            ? current.filter((candidate) => candidate !== day)
-                                            : [...current, day].sort()
-                                        )
-                                      }
-                                    >
-                                      {label}
-                                    </Button>
-                                  );
-                                })}
-                              </div>
-                            </CardDialogSection>
-                          ) : null}
-                          {frequency !== 'once' ? (
-                            <CardDialogSection label={t('household.choreDialog.excludedDates')}>
-                              <Input
-                                aria-label={t('household.choreDialog.excludedDates')}
-                                placeholder="2026-12-24, 2026-12-25"
-                                value={excludedDates}
-                                onChange={(event) => setExcludedDates(event.target.value)}
-                              />
-                            </CardDialogSection>
-                          ) : null}
-                          <CardDialogSection label={t('household.choreDialog.dueWindow')}>
-                            <Input
-                              aria-label={t('household.choreDialog.dueWindow')}
-                              min={0}
-                              step={15}
-                              type="number"
-                              value={dueWindowMinutes}
-                              onChange={(event) => setDueWindowMinutes(Number(event.target.value))}
-                            />
-                          </CardDialogSection>
-                        </ChoreFormGroup>
-                      </div>
-                    ) : null}
-
-                    {editorSection === 'options' ? (
-                      <div className="mt-7">
-                        <ChoreFormGroup title={t('household.choreDialog.moreOptions')}>
-                          <CardDialogSection label={t('household.choreDialog.missedGrace')}>
-                            <Input
-                              aria-label={t('household.choreDialog.missedGrace')}
-                              min={0}
-                              type="number"
-                              value={missedGraceMinutes}
-                              onChange={(event) =>
-                                setMissedGraceMinutes(Number(event.target.value))
-                              }
-                            />
-                          </CardDialogSection>
-                          <CardDialogSection label={t('household.choreDialog.missedAction')}>
-                            <Select
-                              aria-label={t('household.choreDialog.missedAction')}
-                              value={missedAction}
-                              onChange={(event) =>
-                                setMissedAction(
-                                  event.target.value as 'none' | 'skip' | 'carry_forward'
-                                )
-                              }
-                            >
-                              <option value="none">{t('household.choreDialog.missedNone')}</option>
-                              <option value="skip">{t('household.choreDialog.missedSkip')}</option>
-                              <option value="carry_forward">
-                                {t('household.choreDialog.missedCarryForward')}
-                              </option>
-                            </Select>
-                          </CardDialogSection>
-                          <div
-                            className={cn(
-                              'flex min-h-12 items-center justify-between gap-4 rounded-2xl border px-4 sm:col-span-2',
-                              surface.borderStrong,
-                              surface.subtleBg,
-                              surface.textPrimary
-                            )}
-                          >
-                            <span className="text-sm font-medium">
-                              {t('household.choreDialog.reminders')}
-                            </span>
-                            <Switch
-                              aria-label={t('household.choreDialog.reminders')}
-                              checked={remindersEnabled}
-                              size="compact"
-                              onCheckedChange={setRemindersEnabled}
-                            />
-                          </div>
-                          {remindersEnabled ? (
-                            <>
-                              <CardDialogSection label={t('household.choreDialog.remindBefore')}>
-                                <Input
-                                  aria-label={t('household.choreDialog.remindBefore')}
-                                  min={1}
-                                  type="number"
-                                  value={remindBeforeMinutes}
-                                  onChange={(event) =>
-                                    setRemindBeforeMinutes(Number(event.target.value))
-                                  }
-                                />
-                              </CardDialogSection>
-                              <CardDialogSection label={t('household.choreDialog.overdueEvery')}>
-                                <Input
-                                  aria-label={t('household.choreDialog.overdueEvery')}
-                                  min={1}
-                                  type="number"
-                                  value={overdueEveryMinutes}
-                                  onChange={(event) =>
-                                    setOverdueEveryMinutes(Number(event.target.value))
-                                  }
-                                />
-                              </CardDialogSection>
-                            </>
-                          ) : null}
-                        </ChoreFormGroup>
-                      </div>
-                    ) : null}
-                  </div>
-                  <div
-                    className={cn(
-                      'sticky bottom-0 border-t px-4 py-3 sm:px-7',
-                      surface.border,
-                      surface.shellPanel
-                    )}
-                  >
-                    <div className="flex w-full items-center justify-between gap-3">
-                      {isCreationStepper && activeEditorIndex > 0 ? (
-                        <Button
-                          type="button"
-                          variant="secondary"
-                          onClick={() => selectEditorSection(activeEditorIndex - 1)}
-                        >
-                          {t('login.actions.back')}
-                        </Button>
-                      ) : (
-                        <Button
-                          type="button"
-                          variant="secondary"
-                          onClick={() => onOpenChange(false)}
-                        >
-                          {t('common.cancel')}
-                        </Button>
-                      )}
-                      {isCreationStepper && activeEditorIndex < editorSections.length - 1 ? (
-                        <Button type="submit" disabled={!canContinue}>
-                          {t('dashboard.multiple.create.next')}
-                        </Button>
-                      ) : (
-                        <Button type="submit" loading={saving} disabled={!canContinue}>
-                          {definition
-                            ? t('household.choreDialog.saveChanges')
-                            : t('household.choreDialog.save')}
-                        </Button>
-                      )}
-                    </div>
-                  </div>
+            <ChoreCreationFormGroups
+              title={title}
+              icon={choreIcon}
+              roomId={roomLabel}
+              rooms={roomChoices}
+              assignmentMode={assignmentMode}
+              participantId={participantId}
+              participants={completers}
+              repeat={repeatValue}
+              dueTime={time}
+              startDate={scheduleStartDate}
+              endDate={scheduleEndDate}
+              interval={scheduleInterval}
+              excludedDates={excludedDates}
+              showTemplates={!definition}
+              showCustomInterval
+              onTitleChange={setTitle}
+              onIconChange={setChoreIcon}
+              onRoomChange={setRoomLabel}
+              onAssignmentModeChange={setAssignmentMode}
+              onParticipantChange={setParticipantId}
+              onRepeatChange={selectRepeat}
+              onDueTimeChange={setTime}
+              onStartDateChange={setScheduleStartDate}
+              onEndDateChange={setScheduleEndDate}
+              onIntervalChange={setScheduleInterval}
+              onExcludedDatesChange={setExcludedDates}
+            >
+              <ChoreCreationSectionOptions section="details">
+                <CardDialogSection
+                  className="mb-0 sm:col-span-2"
+                  label={t('household.choreDialog.instructions')}
+                >
+                  <Textarea
+                    aria-label={t('household.choreDialog.instructions')}
+                    value={description}
+                    onChange={(event) => setDescription(event.target.value)}
+                  />
+                </CardDialogSection>
+                <CardDialogSection
+                  className="mb-0"
+                  label={t('household.choreDialog.estimatedTime')}
+                >
+                  <Input
+                    aria-label={t('household.choreDialog.estimatedTime')}
+                    min={0}
+                    max={1440}
+                    type="number"
+                    value={estimatedMinutes}
+                    onChange={(event) => setEstimatedMinutes(Number(event.target.value))}
+                  />
+                </CardDialogSection>
+                <CardDialogSection className="mb-0" label={t('household.choreDialog.points')}>
+                  <Input
+                    aria-label={t('household.choreDialog.points')}
+                    min={0}
+                    max={10000}
+                    type="number"
+                    value={points}
+                    onChange={(event) => setPoints(Number(event.target.value))}
+                  />
+                </CardDialogSection>
+                <CardDialogSection className="mb-0" label={t('household.choreDialog.childTitle')}>
+                  <Input
+                    aria-label={t('household.choreDialog.childTitle')}
+                    value={childTitle}
+                    onChange={(event) => setChildTitle(event.target.value)}
+                  />
+                </CardDialogSection>
+              </ChoreCreationSectionOptions>
+              <ChoreCreationSectionOptions section="assignment">
+                <div
+                  className={cn(
+                    'flex min-h-12 items-center justify-between gap-4 rounded-2xl border px-4 sm:col-span-2',
+                    surface.borderStrong,
+                    surface.panelMuted,
+                    surface.textPrimary
+                  )}
+                >
+                  <span className="text-sm font-medium">{t('household.choreDialog.approval')}</span>
+                  <Switch
+                    aria-label={t('household.choreDialog.approval')}
+                    checked={approvalRequired}
+                    size="compact"
+                    disabled={approverIds.length === 0}
+                    onCheckedChange={setApprovalRequired}
+                  />
                 </div>
-              </NavigationWorkspace.ScrollArea>
-            </NavigationWorkspace.Content>
-          </NavigationWorkspace.Body>
-        </NavigationWorkspace.Frame>
+                {assignmentMode === 'rotation' ? (
+                  <>
+                    <CardDialogSection
+                      className="mb-0"
+                      label={t('household.choreDialog.rotationReset')}
+                    >
+                      <Select
+                        aria-label={t('household.choreDialog.rotationReset')}
+                        value={rotationReset}
+                        onChange={(event) =>
+                          setRotationReset(event.target.value as 'never' | 'weekly' | 'monthly')
+                        }
+                      >
+                        <option value="never">{t('household.choreDialog.rotationNever')}</option>
+                        <option value="weekly">{t('household.schedule.weekly')}</option>
+                        <option value="monthly">{t('household.schedule.monthly')}</option>
+                      </Select>
+                    </CardDialogSection>
+                    <CardDialogSection
+                      className="mb-0"
+                      label={t('household.choreDialog.rotationOffset')}
+                    >
+                      <Input
+                        aria-label={t('household.choreDialog.rotationOffset')}
+                        min={0}
+                        type="number"
+                        value={rotationOffset}
+                        onChange={(event) => setRotationOffset(Number(event.target.value))}
+                      />
+                    </CardDialogSection>
+                  </>
+                ) : null}
+                {assignmentMode === 'rotation' || assignmentMode === 'everyone'
+                  ? completers.map((participant) => (
+                      <CardDialogSection
+                        key={participant.id}
+                        className="mb-0"
+                        label={t('household.choreDialog.personTimes', {
+                          name: participant.displayName,
+                        })}
+                      >
+                        <Input
+                          aria-label={t('household.choreDialog.personTimes', {
+                            name: participant.displayName,
+                          })}
+                          placeholder="08:00, 20:00"
+                          value={participantTimes[participant.id] ?? ''}
+                          onChange={(event) =>
+                            setParticipantTimes((current) => ({
+                              ...current,
+                              [participant.id]: event.target.value,
+                            }))
+                          }
+                        />
+                      </CardDialogSection>
+                    ))
+                  : null}
+                <div
+                  className={cn(
+                    'flex min-h-12 items-center justify-between gap-4 rounded-2xl border px-4 sm:col-span-2',
+                    surface.borderStrong,
+                    surface.panelMuted,
+                    surface.textPrimary
+                  )}
+                >
+                  <span className="text-sm font-medium">
+                    {t('household.choreDialog.claimRequired')}
+                  </span>
+                  <Switch
+                    aria-label={t('household.choreDialog.claimRequired')}
+                    checked={claimRequired}
+                    size="compact"
+                    onCheckedChange={setClaimRequired}
+                  />
+                </div>
+                {claimRequired ? (
+                  <CardDialogSection
+                    className="mb-0"
+                    label={t('household.choreDialog.claimExpiry')}
+                  >
+                    <Input
+                      aria-label={t('household.choreDialog.claimExpiry')}
+                      min={1}
+                      type="number"
+                      value={claimExpiryMinutes}
+                      onChange={(event) => setClaimExpiryMinutes(Number(event.target.value))}
+                    />
+                  </CardDialogSection>
+                ) : null}
+              </ChoreCreationSectionOptions>
+              <ChoreCreationSectionOptions section="schedule">
+                {frequency === 'daily' || frequency === 'weekly' ? (
+                  <CardDialogSection
+                    className="mb-0 sm:col-span-2"
+                    label={t('household.choreDialog.weekdays')}
+                  >
+                    <div className="flex flex-wrap gap-1.5">
+                      {Array.from({ length: 7 }, (_, day) => {
+                        const selected = weeklyDays.includes(day);
+                        const label = new Intl.DateTimeFormat(undefined, {
+                          weekday: 'short',
+                        }).format(new Date(Date.UTC(2026, 7, 2 + day)));
+                        return (
+                          <Button
+                            key={day}
+                            type="button"
+                            size="compact"
+                            variant={selected ? 'secondary' : 'ghost'}
+                            className="min-h-9 min-w-9 px-2"
+                            aria-pressed={selected}
+                            onClick={() =>
+                              setWeeklyDays((current) =>
+                                selected
+                                  ? current.filter((candidate) => candidate !== day)
+                                  : [...current, day].sort()
+                              )
+                            }
+                          >
+                            {label}
+                          </Button>
+                        );
+                      })}
+                    </div>
+                  </CardDialogSection>
+                ) : null}
+                <CardDialogSection className="mb-0" label={t('household.choreDialog.dueWindow')}>
+                  <Input
+                    aria-label={t('household.choreDialog.dueWindow')}
+                    min={0}
+                    step={15}
+                    type="number"
+                    value={dueWindowMinutes}
+                    onChange={(event) => setDueWindowMinutes(Number(event.target.value))}
+                  />
+                </CardDialogSection>
+                <CardDialogSection className="mb-0" label={t('household.choreDialog.missedGrace')}>
+                  <Input
+                    aria-label={t('household.choreDialog.missedGrace')}
+                    min={0}
+                    type="number"
+                    value={missedGraceMinutes}
+                    onChange={(event) => setMissedGraceMinutes(Number(event.target.value))}
+                  />
+                </CardDialogSection>
+                <CardDialogSection className="mb-0" label={t('household.choreDialog.missedAction')}>
+                  <Select
+                    aria-label={t('household.choreDialog.missedAction')}
+                    value={missedAction}
+                    onChange={(event) =>
+                      setMissedAction(event.target.value as 'none' | 'skip' | 'carry_forward')
+                    }
+                  >
+                    <option value="none">{t('household.choreDialog.missedNone')}</option>
+                    <option value="skip">{t('household.choreDialog.missedSkip')}</option>
+                    <option value="carry_forward">
+                      {t('household.choreDialog.missedCarryForward')}
+                    </option>
+                  </Select>
+                </CardDialogSection>
+                <div
+                  className={cn(
+                    'flex min-h-12 items-center justify-between gap-4 rounded-2xl border px-4 sm:col-span-2',
+                    surface.borderStrong,
+                    surface.panelMuted,
+                    surface.textPrimary
+                  )}
+                >
+                  <span className="text-sm font-medium">
+                    {t('household.choreDialog.reminders')}
+                  </span>
+                  <Switch
+                    aria-label={t('household.choreDialog.reminders')}
+                    checked={remindersEnabled}
+                    size="compact"
+                    onCheckedChange={setRemindersEnabled}
+                  />
+                </div>
+                {remindersEnabled ? (
+                  <>
+                    <CardDialogSection
+                      className="mb-0"
+                      label={t('household.choreDialog.remindBefore')}
+                    >
+                      <Input
+                        aria-label={t('household.choreDialog.remindBefore')}
+                        min={1}
+                        type="number"
+                        value={remindBeforeMinutes}
+                        onChange={(event) => setRemindBeforeMinutes(Number(event.target.value))}
+                      />
+                    </CardDialogSection>
+                    <CardDialogSection
+                      className="mb-0"
+                      label={t('household.choreDialog.overdueEvery')}
+                    >
+                      <Input
+                        aria-label={t('household.choreDialog.overdueEvery')}
+                        min={1}
+                        type="number"
+                        value={overdueEveryMinutes}
+                        onChange={(event) => setOverdueEveryMinutes(Number(event.target.value))}
+                      />
+                    </CardDialogSection>
+                  </>
+                ) : null}
+              </ChoreCreationSectionOptions>
+            </ChoreCreationFormGroups>
+          </main>
+        </div>
+
+        <footer className={cn('border-t px-4 py-3 sm:px-6', surface.border, surface.shellPanel)}>
+          <div className="mx-auto flex w-full max-w-[50rem] items-center justify-between gap-3">
+            <Button type="button" variant="secondary" onClick={() => onOpenChange(false)}>
+              {t('common.cancel')}
+            </Button>
+            <Button type="submit" loading={saving} disabled={!canSave}>
+              {definition
+                ? t('household.choreDialog.saveChanges')
+                : t('household.choreDialog.save')}
+            </Button>
+          </div>
+        </footer>
       </form>
     </BaseCardDialog>
   );

--- a/packages/app/src/features/chores/components/chore-today-view.tsx
+++ b/packages/app/src/features/chores/components/chore-today-view.tsx
@@ -201,7 +201,9 @@ export function ChoreTodayView({
   const missions = useMemo(() => getMissionProgressList(data, now), [data, now]);
   const rewards = useMemo(() => getRewardProgressList(data), [data]);
   const activeMission =
-    missions.find((mission) => mission.mission.status === 'active') ?? missions[0];
+    experience.gamificationMode !== 'off'
+      ? (missions.find((mission) => mission.mission.status === 'active') ?? missions[0])
+      : undefined;
   const rewardGoal = experience.gamificationMode !== 'off' ? rewards[0] : undefined;
   const hasRewardsSection = Boolean(activeMission || rewardGoal);
   const childMode = experience.gamificationMode === 'adventure';

--- a/packages/app/src/features/chores/components/household-section.stories.tsx
+++ b/packages/app/src/features/chores/components/household-section.stories.tsx
@@ -369,22 +369,22 @@ export const HouseSettled: Story = {
 
 export const MotivationOff: Story = {
   args: { mode: 'off' },
-  play: async ({ canvas }) => {
+  play: async ({ canvas, userEvent }) => {
     const today = within(canvas.getByRole('region', { name: 'Today' }));
+    const navigation = within(canvas.getByRole('navigation', { name: 'Household' }));
     const pulseHeading = await today.findByText('House pulse');
     const pulse = pulseHeading.closest('[data-house-pulse-layout="responsive"]');
     await expect(pulse).toHaveAttribute('data-house-pulse-density', 'inline-metrics');
     await expect(pulse).toHaveClass('lg:landscape:flex', 'xl:flex');
     await expect(pulse?.querySelector('[data-house-pulse-metrics="true"]')).toHaveClass(
       'grid-cols-2',
-      'sm:grid-cols-3',
+      'sm:grid-cols-2',
       'lg:landscape:contents',
       'xl:contents'
     );
     const inlineMetrics = pulse?.querySelectorAll('[data-pulse-metric="true"]') ?? [];
-    await expect(inlineMetrics).toHaveLength(3);
+    await expect(inlineMetrics).toHaveLength(2);
     await expect(inlineMetrics[1]).toHaveClass('border-l');
-    await expect(inlineMetrics[2]).toHaveClass('col-span-2', 'sm:col-span-1', 'sm:border-l');
     await expect(inlineMetrics[0]).toHaveClass('lg:landscape:ml-auto', 'xl:ml-auto');
     await expect(pulse?.querySelector('[data-house-pulse-actions="true"]')).toHaveClass(
       'lg:landscape:ml-3',
@@ -403,6 +403,19 @@ export const MotivationOff: Story = {
     }
     await expect(today.queryByText('Earned')).not.toBeInTheDocument();
     await expect(today.queryByTitle(/points$/)).not.toBeInTheDocument();
+    await expect(navigation.queryByRole('button', { name: 'Missions' })).not.toBeInTheDocument();
+    await expect(navigation.queryByRole('button', { name: 'Rewards' })).not.toBeInTheDocument();
+    await expect(today.queryByText('Missions and rewards')).not.toBeInTheDocument();
+
+    await userEvent.click(navigation.getByRole('button', { name: 'Chores' }));
+    const chores = within(canvas.getByRole('region', { name: 'Chores' }));
+    const dishwasherCard = chores
+      .getByRole('heading', { name: 'Unload dishwasher' })
+      .closest('[data-chore-base-card]');
+    await expect(dishwasherCard).not.toBeNull();
+    await expect(
+      within(dishwasherCard as HTMLElement).queryByTitle('15 points')
+    ).not.toBeInTheDocument();
   },
 };
 

--- a/packages/app/src/features/chores/components/household-section.tsx
+++ b/packages/app/src/features/chores/components/household-section.tsx
@@ -605,6 +605,12 @@ export function HouseholdSection({ syncEnabled = true }: { syncEnabled?: boolean
   };
 
   const experience = normalizeChoreExperienceState(data?.experience);
+  const motivationEnabled = experience.gamificationMode !== 'off';
+  useEffect(() => {
+    if (!motivationEnabled && (view === 'missions' || view === 'rewards')) {
+      setView('today');
+    }
+  }, [motivationEnabled, view]);
   const activeDefinitions = Object.values(data?.definitionsById ?? {}).filter(
     (definition) => !definition.archivedAt
   );
@@ -685,8 +691,12 @@ export function HouseholdSection({ syncEnabled = true }: { syncEnabled?: boolean
           {[
             { value: 'today' as const, label: t('household.tabs.today') },
             { value: 'chores' as const, label: t('household.tabs.chores') },
-            { value: 'missions' as const, label: t('household.tabs.missions') },
-            { value: 'rewards' as const, label: t('household.tabs.rewards') },
+            ...(motivationEnabled
+              ? [
+                  { value: 'missions' as const, label: t('household.tabs.missions') },
+                  { value: 'rewards' as const, label: t('household.tabs.rewards') },
+                ]
+              : []),
             { value: 'progress' as const, label: t('household.tabs.progress') },
             { value: 'settings' as const, label: t('household.tabs.settings') },
             { value: 'routines' as const, label: t('household.tabs.routines') },
@@ -777,54 +787,58 @@ export function HouseholdSection({ syncEnabled = true }: { syncEnabled?: boolean
           ) : null
         )}
       </HouseholdViewPanel>
-      <HouseholdViewPanel value="missions" activeValue={view}>
-        {renderWorkspace(
-          data ? (
-            <MissionsView
-              data={data}
-              onAdd={() => {
-                setMissionToEdit(null);
-                setMissionDialogOpen(true);
-              }}
-              onEdit={(mission) => {
-                setMissionToEdit(mission);
-                setMissionDialogOpen(true);
-              }}
-              onDelete={(mission) =>
-                void updateExperience((current) => {
-                  const missionsById = { ...current.missionsById };
-                  delete missionsById[mission.id];
-                  return { ...current, missionsById };
-                })
-              }
-            />
-          ) : null
-        )}
-      </HouseholdViewPanel>
-      <HouseholdViewPanel value="rewards" activeValue={view}>
-        {renderWorkspace(
-          data ? (
-            <RewardsView
-              data={data}
-              onAdd={() => {
-                setRewardToEdit(null);
-                setRewardDialogOpen(true);
-              }}
-              onEdit={(reward) => {
-                setRewardToEdit(reward);
-                setRewardDialogOpen(true);
-              }}
-              onDelete={(reward) =>
-                void updateExperience((current) => {
-                  const rewardGoalsById = { ...current.rewardGoalsById };
-                  delete rewardGoalsById[reward.id];
-                  return { ...current, rewardGoalsById };
-                })
-              }
-            />
-          ) : null
-        )}
-      </HouseholdViewPanel>
+      {motivationEnabled ? (
+        <>
+          <HouseholdViewPanel value="missions" activeValue={view}>
+            {renderWorkspace(
+              data ? (
+                <MissionsView
+                  data={data}
+                  onAdd={() => {
+                    setMissionToEdit(null);
+                    setMissionDialogOpen(true);
+                  }}
+                  onEdit={(mission) => {
+                    setMissionToEdit(mission);
+                    setMissionDialogOpen(true);
+                  }}
+                  onDelete={(mission) =>
+                    void updateExperience((current) => {
+                      const missionsById = { ...current.missionsById };
+                      delete missionsById[mission.id];
+                      return { ...current, missionsById };
+                    })
+                  }
+                />
+              ) : null
+            )}
+          </HouseholdViewPanel>
+          <HouseholdViewPanel value="rewards" activeValue={view}>
+            {renderWorkspace(
+              data ? (
+                <RewardsView
+                  data={data}
+                  onAdd={() => {
+                    setRewardToEdit(null);
+                    setRewardDialogOpen(true);
+                  }}
+                  onEdit={(reward) => {
+                    setRewardToEdit(reward);
+                    setRewardDialogOpen(true);
+                  }}
+                  onDelete={(reward) =>
+                    void updateExperience((current) => {
+                      const rewardGoalsById = { ...current.rewardGoalsById };
+                      delete rewardGoalsById[reward.id];
+                      return { ...current, rewardGoalsById };
+                    })
+                  }
+                />
+              ) : null
+            )}
+          </HouseholdViewPanel>
+        </>
+      ) : null}
       <HouseholdViewPanel value="progress" activeValue={view}>
         {renderWorkspace(
           data ? (

--- a/packages/app/src/features/dashboard/clients/dashboard-profile-base-cache.test.ts
+++ b/packages/app/src/features/dashboard/clients/dashboard-profile-base-cache.test.ts
@@ -1,4 +1,5 @@
 import { DASHBOARD_CONFIG_VERSION } from '@navet/app/constants/dashboard-config-version';
+import { createLegacyDashboardCollection } from '@navet/app/features/dashboard/dashboards';
 import type { DashboardConfigPayload } from '@navet/app/utils/dashboard-config';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -231,6 +232,35 @@ describe('dashboard profile base cache', () => {
     );
     expect(getDashboardProfileFingerprint(changedProfile)).not.toBe(
       getDashboardProfileFingerprint(profile)
+    );
+  });
+
+  it('ignores the legacy Home projection when fingerprinting a multi-dashboard profile', () => {
+    const dashboards = createLegacyDashboardCollection({
+      homeLayout: {
+        mode: 'flow',
+        showHero: true,
+        cardIds: ['home_assistant:light.kitchen'],
+        sections: [],
+        cardSectionAssignments: {},
+      },
+    });
+    const raspberryPiProfile = {
+      ...profile,
+      version: DASHBOARD_CONFIG_VERSION,
+      dashboards,
+      homeDashboardLayout: dashboards.dashboardsById.home?.homeLayout,
+    } satisfies DashboardConfigPayload;
+    const computerProfile = {
+      ...raspberryPiProfile,
+      homeDashboardLayout: {
+        ...dashboards.dashboardsById.home?.homeLayout,
+        cardIds: ['home_assistant:light.kitchen', 'home_assistant:sensor.office_temperature'],
+      },
+    } satisfies DashboardConfigPayload;
+
+    expect(getDashboardProfileFingerprint(computerProfile)).toBe(
+      getDashboardProfileFingerprint(raspberryPiProfile)
     );
   });
 

--- a/packages/app/src/features/dashboard/clients/dashboard-profile-base-cache.ts
+++ b/packages/app/src/features/dashboard/clients/dashboard-profile-base-cache.ts
@@ -296,12 +296,23 @@ function canonicalizeProfileValue(value: unknown, root = false): unknown {
     return value.map((entry) => canonicalizeProfileValue(entry));
   }
   if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    const hasDashboardCollection =
+      root &&
+      record.dashboards !== null &&
+      typeof record.dashboards === 'object' &&
+      !Array.isArray(record.dashboards);
     return Object.fromEntries(
       Object.keys(value)
-        .filter((key) => !root || !PROFILE_FINGERPRINT_IGNORED_ROOT_KEYS.has(key))
+        .filter(
+          (key) =>
+            !root ||
+            (!PROFILE_FINGERPRINT_IGNORED_ROOT_KEYS.has(key) &&
+              !(key === 'homeDashboardLayout' && hasDashboardCollection))
+        )
         .sort()
         .flatMap((key) => {
-          const entry = (value as Record<string, unknown>)[key];
+          const entry = record[key];
           return entry === undefined ? [] : ([[key, canonicalizeProfileValue(entry)]] as const);
         })
     );

--- a/packages/app/src/features/dashboard/clients/dashboard-profile-diff.test.ts
+++ b/packages/app/src/features/dashboard/clients/dashboard-profile-diff.test.ts
@@ -124,6 +124,40 @@ describe('dashboard profile diff and merge', () => {
     ]);
   });
 
+  it('ignores legacy Home projections when the dashboard collection is authoritative', () => {
+    const dashboards = createLegacyDashboardCollection({
+      homeLayout: {
+        mode: 'flow',
+        showHero: true,
+        cardIds: ['home_assistant:light.kitchen'],
+        sections: [],
+        cardSectionAssignments: {},
+      },
+    });
+    const base = buildProfile({
+      dashboards,
+      homeDashboardLayout: {
+        mode: 'flow',
+        showHero: true,
+        cardIds: ['home_assistant:light.kitchen'],
+        sections: [],
+        cardSectionAssignments: {},
+      },
+    });
+    const next = buildProfile({
+      dashboards,
+      homeDashboardLayout: {
+        mode: 'flow',
+        showHero: true,
+        cardIds: ['home_assistant:light.kitchen', 'home_assistant:sensor.office_temperature'],
+        sections: [],
+        cardSectionAssignments: {},
+      },
+    });
+
+    expect(getDashboardProfileChangedPaths(base, next)).toEqual([]);
+  });
+
   it('reports only overlapping field edits as conflicts', () => {
     const base = buildProfile();
     const local = buildProfile({

--- a/packages/app/src/features/dashboard/clients/dashboard-profile-diff.ts
+++ b/packages/app/src/features/dashboard/clients/dashboard-profile-diff.ts
@@ -11,6 +11,20 @@ export interface DashboardProfileMergeResult {
 
 const IGNORED_ROOT_KEYS = new Set(['cardOrders', 'exportedAt', 'navigation']);
 
+function shouldIgnoreRootKey(key: string, base: JsonRecord, next: JsonRecord) {
+  if (IGNORED_ROOT_KEYS.has(key)) {
+    return true;
+  }
+
+  // Multi-dashboard profiles own Home layout inside `dashboardsById`. The old
+  // top-level projection can legitimately differ between clients assigned to
+  // different dashboards, so it is import compatibility data rather than
+  // shared sync state once both profiles contain a dashboard collection.
+  return (
+    key === 'homeDashboardLayout' && isJsonRecord(base.dashboards) && isJsonRecord(next.dashboards)
+  );
+}
+
 function isJsonRecord(value: unknown): value is JsonRecord {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
@@ -71,7 +85,7 @@ function collectChangedPaths(
   if (isJsonRecord(base) && isJsonRecord(next)) {
     const keys = new Set([...Object.keys(base), ...Object.keys(next)]);
     for (const key of Array.from(keys).sort()) {
-      if (segments.length === 0 && IGNORED_ROOT_KEYS.has(key)) {
+      if (segments.length === 0 && shouldIgnoreRootKey(key, base, next)) {
         continue;
       }
       collectChangedPaths(base[key], next[key], [...segments, key], changedPaths);

--- a/packages/app/src/features/dashboard/components/__tests__/dashboard-section-router-home-controls.test.tsx
+++ b/packages/app/src/features/dashboard/components/__tests__/dashboard-section-router-home-controls.test.tsx
@@ -201,6 +201,19 @@ describe('DashboardSectionRouter home controls', () => {
     expect(screen.queryByText('Household dashboard')).not.toBeInTheDocument();
   });
 
+  it('does not expose dashboard customize actions in the household workspace', async () => {
+    const controller = createController();
+    controller.activeSection = 'tasks';
+
+    renderWithProviders(<DashboardSectionRouter controller={controller} />);
+
+    expect(await screen.findByText('Household dashboard')).toBeInTheDocument();
+    const layoutProps = dashboardLayoutMock.mock.calls[0]?.[0] as {
+      mobileEditActions?: Record<string, unknown>;
+    };
+    expect(layoutProps.mobileEditActions).toBeUndefined();
+  });
+
   it('rerenders when independently consumed controller inputs change', async () => {
     const controller = createController();
     const { rerender } = renderWithProviders(<DashboardSectionRouter controller={controller} />);
@@ -235,6 +248,7 @@ describe('DashboardSectionRouter home controls', () => {
     nextController = {
       ...nextController,
       securityAlertCount: 1,
+      activeRoomSecurityAlertCount: 1,
     };
     rerender(<DashboardSectionRouter controller={nextController} />);
     expect(dashboardLayoutMock).toHaveBeenCalled();
@@ -404,6 +418,7 @@ function createController(): DashboardController {
     roomItemCounts: new Map(),
     rooms: [ALL_ROOMS_ID, 'Kitchen'],
     securityAlertCount: 0,
+    activeRoomSecurityAlertCount: 0,
     sectionData: {
       isOverviewSection: true,
       energyCustomCards: [],

--- a/packages/app/src/features/dashboard/components/dashboard-section-router.tsx
+++ b/packages/app/src/features/dashboard/components/dashboard-section-router.tsx
@@ -273,6 +273,7 @@ function DashboardSectionRouterComponent({ controller }: DashboardSectionRouterP
         pendingChoreCount: roomTodayChores.length > 0 ? pendingRoomChores.length : undefined,
         overdueChoreCount: overdueRoomChoreCount,
         routineCount,
+        securityAlertCount: controller.activeRoomSecurityAlertCount,
         temperatureUnit,
       },
       t
@@ -283,6 +284,7 @@ function DashboardSectionRouterComponent({ controller }: DashboardSectionRouterP
     pendingRoomChores.length,
     overdueRoomChoreCount,
     roomClimateEntityIds,
+    controller.activeRoomSecurityAlertCount,
     roomTodayChores.length,
     routines.automations,
     routines.quickActions,
@@ -684,7 +686,7 @@ function DashboardSectionRouterComponent({ controller }: DashboardSectionRouterP
     <DashboardLayout
       densePerformanceMode={controller.densePerformanceMode}
       mobileEditActions={
-        isEditMode
+        isEditMode || activeSection === 'tasks'
           ? undefined
           : {
               isEditMode,
@@ -785,6 +787,8 @@ function areDashboardSectionRouterPropsEqual(
     previousController.roomItemCounts === nextController.roomItemCounts &&
     previousController.rooms === nextController.rooms &&
     previousController.securityAlertCount === nextController.securityAlertCount &&
+    previousController.activeRoomSecurityAlertCount ===
+      nextController.activeRoomSecurityAlertCount &&
     previousController.sectionData === nextController.sectionData &&
     previousController.setActiveSection === nextController.setActiveSection &&
     previousController.updateCardSize === nextController.updateCardSize &&

--- a/packages/app/src/features/dashboard/hooks/__tests__/use-dashboard-profile-sync.test.tsx
+++ b/packages/app/src/features/dashboard/hooks/__tests__/use-dashboard-profile-sync.test.tsx
@@ -19,6 +19,7 @@ import {
 import { useDashboardProfileRuntimeStore } from '@navet/app/features/dashboard/clients/dashboard-profile-runtime-store';
 import { emptyDeviceDisplayProfilePolicy } from '@navet/app/features/dashboard/clients/device-display-profile';
 import { useDeviceDisplayProfileRuntimeStore } from '@navet/app/features/dashboard/clients/device-display-profile-runtime-store';
+import { createLegacyDashboardCollection } from '@navet/app/features/dashboard/dashboards';
 import {
   DASHBOARD_PROFILE_REFRESH_EVENT,
   useDashboardProfileSync,
@@ -738,6 +739,44 @@ describe('useDashboardProfileSync', () => {
     });
   });
 
+  it('does not report a conflict for different legacy projections of the same dashboard collection', async () => {
+    const dashboards = createLegacyDashboardCollection({
+      homeLayout: {
+        mode: 'flow',
+        showHero: true,
+        cardIds: ['home_assistant:light.kitchen'],
+        sections: [],
+        cardSectionAssignments: {},
+      },
+    });
+    const remote = buildProfile({
+      dashboards,
+      homeDashboardLayout: dashboards.dashboardsById.home?.homeLayout,
+    });
+    currentProfile = buildProfile({
+      dashboards,
+      homeDashboardLayout: {
+        ...dashboards.dashboardsById.home?.homeLayout,
+        cardIds: ['home_assistant:light.kitchen', 'home_assistant:sensor.office_temperature'],
+      },
+    });
+    loadDashboardProfile.mockResolvedValueOnce(activeResult(remote));
+
+    renderHookWithProviders(() => useDashboardProfileSync());
+    await flushEffects();
+
+    expect(saveDashboardProfile).not.toHaveBeenCalled();
+    expect(importDashboardConfig).not.toHaveBeenCalled();
+    expect(toast).not.toHaveBeenCalledWith(
+      'Dashboard changes detected on another device',
+      expect.anything()
+    );
+    expect(useDashboardProfileRuntimeStore.getState()).toMatchObject({
+      conflict: null,
+      status: 'synced',
+    });
+  });
+
   it('applies a newer remote profile after reload when the local profile has a clean receipt', async () => {
     const previouslySynced = buildProfile();
     const remote = buildProfile({
@@ -1353,7 +1392,7 @@ describe('useDashboardProfileSync', () => {
     expect(loadDashboardProfile).toHaveBeenCalledTimes(2);
   });
 
-  it('applies and attributes a clean update, then keeps polling', async () => {
+  it('applies and attributes a clean update silently, then keeps polling', async () => {
     const base = buildProfile();
     const remote = buildProfile({
       exportedAt: '2026-07-25T09:02:00.000Z',
@@ -1370,13 +1409,7 @@ describe('useDashboardProfileSync', () => {
 
     await advanceTime(60_000);
     expect(importDashboardConfig).toHaveBeenCalledWith(remote, { applyNavigation: false });
-    expect(toast).toHaveBeenCalledWith(
-      'Dashboard updated',
-      expect.objectContaining({
-        description: 'Kitchen panel updated the shared dashboard.',
-        duration: 6_000,
-      })
-    );
+    expect(toast).not.toHaveBeenCalledWith('Dashboard updated', expect.anything());
     expect(useDashboardProfileRuntimeStore.getState().lastActivity?.actor.clientName).toBe(
       'Kitchen panel'
     );

--- a/packages/app/src/features/dashboard/hooks/__tests__/use-home-security-alert-count.test.tsx
+++ b/packages/app/src/features/dashboard/hooks/__tests__/use-home-security-alert-count.test.tsx
@@ -1,9 +1,17 @@
 import { createEmptyDeviceCollection } from '@navet/app/core/navet-device-collections';
 import * as securityDashboardModel from '@navet/app/features/security/utils/security-camera-dashboard-model';
-import type { DeviceCollection, LockDevice, SensorDevice } from '@navet/app/types/device.types';
+import type {
+  CameraDevice,
+  DeviceCollection,
+  LockDevice,
+  SensorDevice,
+} from '@navet/app/types/device.types';
 import { renderHook } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { useHomeSecurityAlertCount } from '../use-home-security-alert-count';
+import {
+  getRoomSecurityAlertCount,
+  useHomeSecurityAlertCount,
+} from '../use-home-security-alert-count';
 
 const EMPTY_HIDDEN_ENTITY_IDS: string[] = [];
 
@@ -84,7 +92,7 @@ describe('useHomeSecurityAlertCount', () => {
     expect(fullModelSpy).not.toHaveBeenCalled();
   });
 
-  it('preserves hidden-parent and absorbed-child alert behavior', () => {
+  it('keeps an absorbed child hidden when its parent card is hidden', () => {
     const parentLock = lock({
       securitySeverity: 'normal',
       state: true,
@@ -119,6 +127,27 @@ describe('useHomeSecurityAlertCount', () => {
 
     rerender({ hiddenEntityIds: [parentLock.id] });
 
-    expect(result.current).toBe(1);
+    expect(result.current).toBe(0);
+  });
+
+  it('excludes a hidden unavailable camera from its room alert count', () => {
+    const unavailableCamera: CameraDevice = {
+      id: 'camera.bedroom',
+      name: 'Bedroom Camera',
+      room: 'Bedroom',
+      size: 'medium',
+      state: 'unavailable',
+      securitySeverity: 'unknown',
+      supportedFeatures: 2,
+      isStreamCapable: true,
+      isStillImageOnly: false,
+    };
+    const devices: DeviceCollection = {
+      ...createEmptyDeviceCollection(),
+      cameras: [unavailableCamera],
+    };
+
+    expect(getRoomSecurityAlertCount(devices, [], 'Bedroom')).toBe(1);
+    expect(getRoomSecurityAlertCount(devices, [unavailableCamera.id], 'Bedroom')).toBe(0);
   });
 });

--- a/packages/app/src/features/dashboard/hooks/use-dashboard-controller.ts
+++ b/packages/app/src/features/dashboard/hooks/use-dashboard-controller.ts
@@ -80,7 +80,10 @@ import { useDashboardRoomNavigation } from './use-dashboard-room-navigation';
 import { useEditModeBeforeUnload } from './use-edit-mode-beforeunload';
 import { useHomeDashboardLayout } from './use-home-dashboard-layout';
 import { useHomeLayoutHydrated } from './use-home-layout-hydrated';
-import { useHomeSecurityAlertCount } from './use-home-security-alert-count';
+import {
+  getRoomSecurityAlertCount,
+  useHomeSecurityAlertCount,
+} from './use-home-security-alert-count';
 import { useOnboardingController } from './use-onboarding-controller';
 
 const DASHBOARD_DEVICE_SECTION_IDS = new Set(['home', 'lights', 'climate']);
@@ -501,6 +504,13 @@ export function useDashboardController(): DashboardController {
     enabled: showHomeSummaryBar && sectionData.isOverviewSection,
     hiddenEntityIds,
   });
+  const activeRoomSecurityAlertCount = useMemo(
+    () =>
+      isAllRooms(activeRoom)
+        ? securityAlertCount
+        : getRoomSecurityAlertCount(allDevices, hiddenEntityIds, activeRoom),
+    [activeRoom, allDevices, hiddenEntityIds, securityAlertCount]
+  );
 
   const resetDashboard = useResetDashboard(resetHomeLayout);
   const onboarding = useOnboardingController({ allEntityIds, changeRoom, resetDashboard });
@@ -636,6 +646,7 @@ export function useDashboardController(): DashboardController {
     rooms,
     sectionData,
     securityAlertCount,
+    activeRoomSecurityAlertCount,
     setActiveSection,
     updateCardSize,
     updateCardZone,

--- a/packages/app/src/features/dashboard/hooks/use-dashboard-controller.types.ts
+++ b/packages/app/src/features/dashboard/hooks/use-dashboard-controller.types.ts
@@ -105,6 +105,7 @@ export type DashboardController = OnboardingController &
     rooms: string[];
     sectionData: DashboardSectionData;
     securityAlertCount: number;
+    activeRoomSecurityAlertCount: number;
     setActiveSection: (section: Section) => void;
     updateCardSize: ReturnType<typeof useCardState>['updateCardSize'];
     updateCardZone: (id: string, zone: ZoneName) => void;

--- a/packages/app/src/features/dashboard/hooks/use-dashboard-profile-sync.ts
+++ b/packages/app/src/features/dashboard/hooks/use-dashboard-profile-sync.ts
@@ -339,21 +339,7 @@ export function useDashboardProfileSync() {
       });
     }
 
-    function notifyRemoteUpdate(result: DashboardProfileLoadResult) {
-      const author = result.metadata?.author;
-      if (!author || author.id === client.id) {
-        return;
-      }
-
-      toast(tRef.current('dashboard.profileSync.updatedTitle'), {
-        description: tRef.current('dashboard.profileSync.updatedDescription', {
-          client: author.name,
-        }),
-        duration: 6_000,
-      });
-    }
-
-    function applyRemoteProfile(result: DashboardProfileLoadResult, notify: boolean) {
+    function applyRemoteProfile(result: DashboardProfileLoadResult) {
       if (!result.profile) {
         return;
       }
@@ -372,9 +358,6 @@ export function useDashboardProfileSync() {
       clearConflict();
       rememberCommonBase(result.profile, result);
       markRemoteSynced(result);
-      if (notify) {
-        notifyRemoteUpdate(result);
-      }
     }
 
     function setRegisteredClients(
@@ -549,7 +532,7 @@ export function useDashboardProfileSync() {
                   const currentConflict = pendingConflict;
                   if (currentConflict) {
                     keepLocalResolution = null;
-                    applyRemoteProfile(currentConflict.remote, false);
+                    applyRemoteProfile(currentConflict.remote);
                   }
                 },
               },
@@ -605,7 +588,7 @@ export function useDashboardProfileSync() {
 
       refreshAfterAuthentication = false;
       clearPollTimeout();
-      void refreshRemote({ forceFull: true, notify: true });
+      void refreshRemote({ forceFull: true });
       return true;
     }
 
@@ -695,7 +678,7 @@ export function useDashboardProfileSync() {
           return false;
         }
         if (!options.keepalive && (result.preconditionFailed || result.preconditionRequired)) {
-          await refreshRemote({ forceFull: true, notify: true });
+          await refreshRemote({ forceFull: true });
           return false;
         }
 
@@ -714,10 +697,7 @@ export function useDashboardProfileSync() {
       }
     }
 
-    async function handleRemoteResult(
-      result: DashboardProfileLoadResult,
-      options: { initial?: boolean; notify?: boolean } = {}
-    ) {
+    async function handleRemoteResult(result: DashboardProfileLoadResult) {
       const resultWorkspaceId = result.workspace?.workspaceId;
       const currentWorkspaceId = remoteResult?.workspace?.workspaceId;
       const isAuthoritativeUninitializedResult =
@@ -838,14 +818,11 @@ export function useDashboardProfileSync() {
         clearConflict();
         rememberCommonBase(result.profile, result);
         markRemoteSynced(result);
-        if (options.notify) {
-          notifyRemoteUpdate(result);
-        }
         return;
       }
 
       if (reconciliation.kind === 'apply-remote') {
-        applyRemoteProfile(result, options.notify === true);
+        applyRemoteProfile(result);
         return;
       }
 
@@ -867,9 +844,6 @@ export function useDashboardProfileSync() {
         }
         pendingLocalChanges = true;
         markRemoteSynced(result);
-        if (options.notify) {
-          notifyRemoteUpdate(result);
-        }
         await saveProfile(getProfileForSync());
         return;
       }
@@ -882,7 +856,7 @@ export function useDashboardProfileSync() {
       });
     }
 
-    async function refreshRemote(options: { forceFull?: boolean; notify?: boolean } = {}) {
+    async function refreshRemote(options: { forceFull?: boolean } = {}) {
       if (cancelled || loadingRemote || (!options.forceFull && !shouldPoll())) {
         return;
       }
@@ -925,9 +899,7 @@ export function useDashboardProfileSync() {
           return;
         }
 
-        await handleRemoteResult(result, {
-          notify: options.notify ?? true,
-        });
+        await handleRemoteResult(result);
         if (clientRegistrationPending) {
           await refreshRegisteredClients(true);
         }
@@ -1035,7 +1007,7 @@ export function useDashboardProfileSync() {
     const handleOnline = () => {
       isOnline = true;
       syncCurrentLocalState();
-      void refreshRemote({ notify: true });
+      void refreshRemote();
     };
     const handleOffline = () => {
       isOnline = false;
@@ -1056,7 +1028,7 @@ export function useDashboardProfileSync() {
         showConflict(pendingConflict);
       }
       syncCurrentLocalState();
-      void refreshRemote({ notify: true });
+      void refreshRemote();
     };
     const handlePageHide = () => {
       if (pendingLocalChanges) {
@@ -1078,7 +1050,7 @@ export function useDashboardProfileSync() {
       }
       clearPollTimeout();
       runtime.markLoading();
-      void refreshRemote({ forceFull: true, notify: true });
+      void refreshRemote({ forceFull: true });
     };
     const handleAuthSessionRefreshed = (event: Event) => {
       const detail = (event as CustomEvent<AuthSessionRefreshedEventDetail>).detail;
@@ -1090,7 +1062,7 @@ export function useDashboardProfileSync() {
         refreshAfterAuthentication = true;
         return;
       }
-      void refreshRemote({ forceFull: true, notify: true });
+      void refreshRemote({ forceFull: true });
     };
 
     window.addEventListener(PERSISTED_STATE_EVENT, handlePersistedState as EventListener);
@@ -1135,7 +1107,7 @@ export function useDashboardProfileSync() {
           permanentAccessFailure = true;
           runtime.markError(tRef.current('dashboard.profileSync.unavailable'));
         } else if (result.available) {
-          await handleRemoteResult(result, { initial: true, notify: false });
+          await handleRemoteResult(result);
         } else {
           runtime.markError(
             tRef.current(

--- a/packages/app/src/features/dashboard/hooks/use-home-security-alert-count.ts
+++ b/packages/app/src/features/dashboard/hooks/use-home-security-alert-count.ts
@@ -4,6 +4,7 @@ import {
   getExpandedHiddenDashboardEntityIds,
 } from '@navet/app/hooks/use-dashboard-devices';
 import type { BaseDevice, DeviceCollection, SecurityKind } from '@navet/app/types/device.types';
+import { getDeviceRoomLabel } from '@navet/app/utils/device-location';
 import { useEffect, useMemo, useRef } from 'react';
 
 type HomeSecurityAlertDevices = Pick<
@@ -67,7 +68,7 @@ export function selectHomeSecurityAlertDevices(
   hiddenEntityIds: string[]
 ): HomeSecurityAlertDevices {
   const expandedHiddenIds = new Set(getExpandedHiddenDashboardEntityIds(devices, hiddenEntityIds));
-  const absorbedIds = new Set(getAbsorbedDashboardEntityIds(devices, [...expandedHiddenIds]));
+  const absorbedIds = new Set(getAbsorbedDashboardEntityIds(devices, []));
 
   return {
     cameras: devices.cameras.filter((device) => !expandedHiddenIds.has(device.id)),
@@ -86,6 +87,21 @@ export function selectHomeSecurityAlertDevices(
         isSupplementalSecurityAlertDevice(device)
     ),
   };
+}
+
+export function getRoomSecurityAlertCount(
+  devices: DeviceCollection,
+  hiddenEntityIds: string[],
+  room: string
+) {
+  const selectedDevices = selectHomeSecurityAlertDevices(devices, hiddenEntityIds);
+  return getSecurityDashboardAlertCount({
+    cameras: selectedDevices.cameras.filter((device) => getDeviceRoomLabel(device) === room),
+    covers: selectedDevices.covers.filter((device) => getDeviceRoomLabel(device) === room),
+    helpers: selectedDevices.helpers.filter((device) => getDeviceRoomLabel(device) === room),
+    locks: selectedDevices.locks.filter((device) => getDeviceRoomLabel(device) === room),
+    sensors: selectedDevices.sensors.filter((device) => getDeviceRoomLabel(device) === room),
+  });
 }
 
 export function useHomeSecurityAlertCount({

--- a/packages/app/src/features/dashboard/rooms/components/room-workspace-panels.tsx
+++ b/packages/app/src/features/dashboard/rooms/components/room-workspace-panels.tsx
@@ -19,10 +19,10 @@ import {
   DashboardEmptyState,
   NavigationWorkspace,
   NavigationWorkspaceHeader,
-  SelectableCheckboxRow,
 } from '@navet/app/components/patterns';
 import {
   Button,
+  Checkbox,
   IconButton,
   Input,
   InteractivePill,
@@ -97,6 +97,91 @@ interface WorkspacePanelProps extends RoomWorkspaceComponentProps {
   surface: SurfaceTokens;
   accentColor: string;
   showInlineSaveBar?: boolean;
+}
+
+function RoomSettingsGroup({
+  title,
+  children,
+  surface,
+}: {
+  title: string;
+  children: ReactNode;
+  surface: SurfaceTokens;
+}) {
+  return (
+    <section>
+      <h3
+        className={cn(
+          'mb-2 px-1 font-semibold',
+          navetTypographyTokens.caption,
+          surface.textSecondary
+        )}
+      >
+        {title}
+      </h3>
+      <div
+        className={cn('rounded-[22px] border p-4 sm:p-5', surface.subtleBg, surface.borderStrong)}
+      >
+        {children}
+      </div>
+    </section>
+  );
+}
+
+function RoomSettingsToggle({
+  checked,
+  disabled,
+  label,
+  description,
+  icon: Icon,
+  onCheckedChange,
+  surface,
+  accentColor,
+}: {
+  checked: boolean;
+  disabled: boolean;
+  label: string;
+  description: string;
+  icon: LucideIcon;
+  onCheckedChange: (checked: boolean) => void;
+  surface: SurfaceTokens;
+  accentColor: string;
+}) {
+  const inputId = useId();
+
+  return (
+    <label
+      htmlFor={inputId}
+      className={cn(
+        'flex min-h-11 cursor-pointer items-center gap-3',
+        disabled && 'cursor-not-allowed opacity-50'
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          'flex h-9 w-9 shrink-0 items-center justify-center rounded-2xl border',
+          surface.iconBg,
+          surface.borderStrong,
+          surface.textSecondary
+        )}
+      >
+        <Icon className={navetIconSizeTokens.sm} />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className={cn('block text-sm font-semibold', surface.textPrimary)}>{label}</span>
+        <span className={cn('block text-xs leading-5', surface.textMuted)}>{description}</span>
+      </span>
+      <Checkbox
+        id={inputId}
+        checked={checked}
+        disabled={disabled}
+        aria-label={label}
+        paletteColor={accentColor}
+        onCheckedChange={(value) => onCheckedChange(Boolean(value))}
+      />
+    </label>
+  );
 }
 
 function RoomDeviceIcon({
@@ -475,14 +560,20 @@ function RoomActionsSection({
   }
 
   return (
-    <section aria-label={labels.roomActionsTitle} className={cn('border-t pt-5', surface.border)}>
-      <h3 className={cn(navetTypographyTokens.titleSm, surface.textPrimary)}>
+    <section aria-label={labels.roomActionsTitle}>
+      <h3
+        className={cn(
+          'mb-2 px-1 font-semibold',
+          navetTypographyTokens.caption,
+          surface.textSecondary
+        )}
+      >
         {labels.roomActionsTitle}
       </h3>
       <div
         className={cn(
-          'mt-3 overflow-hidden rounded-[24px] border',
-          surface.border,
+          'overflow-hidden rounded-[22px] border',
+          surface.borderStrong,
           surface.subtleBg
         )}
       >
@@ -1308,7 +1399,7 @@ export function RoomDetailsPanel({
   accentColor,
   showInlineSaveBar = false,
 }: WorkspacePanelProps) {
-  const [activeSection, setActiveSection] = useState<'settings' | 'devices'>('devices');
+  const [activeSection, setActiveSection] = useState<'settings' | 'devices'>('settings');
   const settingsPanelId = useId();
   const devicesPanelId = useId();
   const room = viewModel.rooms.find((candidate) => candidate.id === viewModel.selectedRoomId);
@@ -1344,18 +1435,6 @@ export function RoomDetailsPanel({
       >
         <CardDialogTabList className="mt-0 flex w-full flex-wrap gap-2">
           <InteractivePill
-            active={activeSection === 'devices'}
-            accentColor={accentColor}
-            size="compact"
-            icon={Layers3}
-            aria-pressed={activeSection === 'devices'}
-            aria-controls={devicesPanelId}
-            onClick={() => setActiveSection('devices')}
-            className="motion-reduce:transition-none"
-          >
-            {labels.devicesTitle}
-          </InteractivePill>
-          <InteractivePill
             active={activeSection === 'settings'}
             accentColor={accentColor}
             size="compact"
@@ -1366,6 +1445,18 @@ export function RoomDetailsPanel({
             className="motion-reduce:transition-none"
           >
             {labels.roomDetailsTitle}
+          </InteractivePill>
+          <InteractivePill
+            active={activeSection === 'devices'}
+            accentColor={accentColor}
+            size="compact"
+            icon={Layers3}
+            aria-pressed={activeSection === 'devices'}
+            aria-controls={devicesPanelId}
+            onClick={() => setActiveSection('devices')}
+            className="motion-reduce:transition-none"
+          >
+            {labels.devicesTitle}
           </InteractivePill>
           {activeSection === 'devices' && actions.onDeviceSelectionChange ? (
             <Button
@@ -1380,129 +1471,130 @@ export function RoomDetailsPanel({
         </CardDialogTabList>
 
         {activeSection === 'settings' ? (
-          <section id={settingsPanelId} aria-label={labels.roomDetailsTitle} className="space-y-5">
-            <div>
-              <label
-                htmlFor={`room-name-${room.id}`}
-                className={cn(navetTypographyTokens.label, surface.textPrimary)}
-              >
-                {labels.roomNameLabel}
-              </label>
-              <Input
-                id={`room-name-${room.id}`}
-                name={`room-name-${room.id}`}
-                value={room.nameDraft ?? room.name}
-                placeholder={labels.roomNamePlaceholder}
-                onChange={(event) => actions.onRoomNameChange?.(room.id, event.currentTarget.value)}
-                disabled={!actions.onRoomNameChange}
-                invalid={Boolean(room.nameValidationMessage)}
-                aria-describedby={
-                  room.nameValidationMessage ? `room-name-error-${room.id}` : undefined
-                }
-                containerClassName="mt-2"
-                inputClassName="min-h-11 motion-reduce:transition-none"
-              />
-              {room.nameValidationMessage ? (
-                <p
-                  id={`room-name-error-${room.id}`}
-                  role="alert"
-                  className={cn('mt-2 text-sm', navetSemanticColorTokens.error)}
-                >
-                  {room.nameValidationMessage}
-                </p>
-              ) : null}
-            </div>
-
-            <div>
-              <label
-                htmlFor={`room-group-${room.id}`}
-                className={cn(navetTypographyTokens.label, surface.textPrimary)}
-              >
-                {labels.groupLabel}
-              </label>
-              <Select
-                id={`room-group-${room.id}`}
-                name={`room-group-${room.id}`}
-                value={room.groupId ?? ''}
-                onChange={(event) =>
-                  actions.onRoomGroupChange?.(room.id, event.currentTarget.value || null)
-                }
-                disabled={!actions.onRoomGroupChange}
-                containerClassName="mt-2"
-                selectClassName="min-h-11 motion-reduce:transition-none"
-              >
-                <option value="">{labels.ungroupedGroup}</option>
-                {viewModel.groups.map((group) => (
-                  <option key={group.id} value={group.id}>
-                    {group.name}
-                  </option>
-                ))}
-              </Select>
-            </div>
-
-            <div className="space-y-3">
-              <SelectableCheckboxRow
+          <section id={settingsPanelId} aria-label={labels.roomDetailsTitle} className="grid gap-6">
+            <RoomSettingsGroup title={labels.visibilityLabel} surface={surface}>
+              <RoomSettingsToggle
                 checked={room.isVisible}
-                onCheckedChange={(visible) => actions.onRoomVisibilityChange?.(room.id, visible)}
                 disabled={!actions.onRoomVisibilityChange}
                 label={labels.visibilityLabel}
                 description={labels.visibilityDescription}
-                leading={<Eye className={cn(navetIconSizeTokens.sm, surface.textSecondary)} />}
-                rowClassName={cn('min-h-14', surface.subtleBg, surface.border)}
-                selectedClassName={surface.borderStrong}
-                labelClassName={surface.textPrimary}
-                descriptionClassName={surface.textMuted}
-                checkboxPaletteColor={accentColor}
+                icon={room.isVisible ? Eye : EyeOff}
+                onCheckedChange={(visible) => actions.onRoomVisibilityChange?.(room.id, visible)}
+                surface={surface}
+                accentColor={accentColor}
               />
-              <SelectableCheckboxRow
-                checked={room.isFavorite}
-                onCheckedChange={(favorite) => actions.onRoomFavoriteChange?.(room.id, favorite)}
-                disabled={!actions.onRoomFavoriteChange}
-                label={labels.favoriteLabel}
-                description={labels.favoriteDescription}
-                leading={<Heart className={cn(navetIconSizeTokens.sm, surface.textSecondary)} />}
-                rowClassName={cn('min-h-14', surface.subtleBg, surface.border)}
-                selectedClassName={surface.borderStrong}
-                labelClassName={surface.textPrimary}
-                descriptionClassName={surface.textMuted}
-                checkboxPaletteColor={accentColor}
-              />
-            </div>
+              <div className={cn('mt-4 border-t pt-4', surface.border)}>
+                <RoomSettingsToggle
+                  checked={room.isFavorite}
+                  disabled={!actions.onRoomFavoriteChange}
+                  label={labels.favoriteLabel}
+                  description={labels.favoriteDescription}
+                  icon={Heart}
+                  onCheckedChange={(favorite) => actions.onRoomFavoriteChange?.(room.id, favorite)}
+                  surface={surface}
+                  accentColor={accentColor}
+                />
+              </div>
+            </RoomSettingsGroup>
 
-            <div
-              className={cn(
-                'grid gap-4 rounded-[24px] border p-4 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center',
-                surface.border,
-                surface.subtleBg
-              )}
-            >
-              <div className="flex min-w-0 items-center gap-4">
-                <RoomSymbol room={room} surface={surface} />
-                <div className="min-w-0 flex-1">
-                  <p className={cn(navetTypographyTokens.titleSm, surface.textPrimary)}>
-                    {labels.appearanceLabel}
-                  </p>
-                  <p className={cn('mt-1 text-sm', surface.textMuted)}>
-                    {labels.appearanceDescription}
-                  </p>
+            <RoomSettingsGroup title={labels.roomDetailsTitle} surface={surface}>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div>
+                  <label
+                    htmlFor={`room-name-${room.id}`}
+                    className={cn(navetTypographyTokens.label, surface.textPrimary)}
+                  >
+                    {labels.roomNameLabel}
+                  </label>
+                  <Input
+                    id={`room-name-${room.id}`}
+                    name={`room-name-${room.id}`}
+                    value={room.nameDraft ?? room.name}
+                    placeholder={labels.roomNamePlaceholder}
+                    onChange={(event) =>
+                      actions.onRoomNameChange?.(room.id, event.currentTarget.value)
+                    }
+                    disabled={!actions.onRoomNameChange}
+                    invalid={Boolean(room.nameValidationMessage)}
+                    aria-describedby={
+                      room.nameValidationMessage ? `room-name-error-${room.id}` : undefined
+                    }
+                    containerClassName="mt-2"
+                    inputClassName="min-h-11 motion-reduce:transition-none"
+                  />
+                  {room.nameValidationMessage ? (
+                    <p
+                      id={`room-name-error-${room.id}`}
+                      role="alert"
+                      className={cn('mt-2 text-sm', navetSemanticColorTokens.error)}
+                    >
+                      {room.nameValidationMessage}
+                    </p>
+                  ) : null}
+                </div>
+
+                <div>
+                  <label
+                    htmlFor={`room-group-${room.id}`}
+                    className={cn(navetTypographyTokens.label, surface.textPrimary)}
+                  >
+                    {labels.groupLabel}
+                  </label>
+                  <Select
+                    id={`room-group-${room.id}`}
+                    name={`room-group-${room.id}`}
+                    value={room.groupId ?? ''}
+                    onChange={(event) =>
+                      actions.onRoomGroupChange?.(room.id, event.currentTarget.value || null)
+                    }
+                    disabled={!actions.onRoomGroupChange}
+                    containerClassName="mt-2"
+                    selectClassName="min-h-11 motion-reduce:transition-none"
+                  >
+                    <option value="">{labels.ungroupedGroup}</option>
+                    {viewModel.groups.map((group) => (
+                      <option key={group.id} value={group.id}>
+                        {group.name}
+                      </option>
+                    ))}
+                  </Select>
+                </div>
+
+                <div
+                  className={cn(
+                    'grid gap-4 border-t pt-4 sm:col-span-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center',
+                    surface.border
+                  )}
+                >
+                  <div className="flex min-w-0 items-center gap-3">
+                    <RoomSymbol room={room} surface={surface} />
+                    <div className="min-w-0 flex-1">
+                      <p className={cn(navetTypographyTokens.titleSm, surface.textPrimary)}>
+                        {labels.appearanceLabel}
+                      </p>
+                      <p className={cn('mt-0.5 text-xs leading-5', surface.textMuted)}>
+                        {labels.appearanceDescription}
+                      </p>
+                    </div>
+                  </div>
+                  {actions.onChooseRoomAppearance ? (
+                    <Button
+                      variant="secondary"
+                      onClick={() => actions.onChooseRoomAppearance?.(room.id)}
+                      leading={<Sparkles className={navetIconSizeTokens.sm} />}
+                      className="min-h-10 shrink-0 motion-reduce:transition-none"
+                    >
+                      {labels.chooseAppearance}
+                    </Button>
+                  ) : null}
+                  <RoomImagePreview
+                    room={room}
+                    surface={surface}
+                    className="sm:col-span-2 sm:aspect-[16/5]"
+                  />
                 </div>
               </div>
-              {actions.onChooseRoomAppearance ? (
-                <Button
-                  variant="secondary"
-                  onClick={() => actions.onChooseRoomAppearance?.(room.id)}
-                  leading={<Sparkles className={navetIconSizeTokens.sm} />}
-                  className="min-h-11 shrink-0 motion-reduce:transition-none"
-                >
-                  {labels.chooseAppearance}
-                </Button>
-              ) : null}
-              <RoomImagePreview
-                room={room}
-                surface={surface}
-                className="sm:col-span-2 sm:aspect-[16/5]"
-              />
-            </div>
+            </RoomSettingsGroup>
 
             <RoomActionsSection room={room} labels={labels} actions={actions} surface={surface} />
           </section>

--- a/packages/app/src/features/dashboard/rooms/components/room-workspace.stories.tsx
+++ b/packages/app/src/features/dashboard/rooms/components/room-workspace.stories.tsx
@@ -788,18 +788,28 @@ export const RoomDetails: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const page = within(canvasElement.ownerDocument.body);
-    await expect(canvas.getByRole('button', { name: 'Devices' })).toHaveAttribute(
+    await expect(canvas.getByRole('button', { name: 'Room settings' })).toHaveAttribute(
       'aria-pressed',
       'true'
     );
     await expect(
       canvas
-        .getByRole('button', { name: 'Devices' })
+        .getByRole('button', { name: 'Room settings' })
         .closest('[data-room-workspace-panel-content="manage"]')
     ).not.toBeNull();
+    const navigationCheckbox = canvas.getByRole('checkbox', { name: 'Show in navigation' });
+    await expect(navigationCheckbox).toBeVisible();
+    await expect(canvas.getAllByText('Show in navigation')).toHaveLength(2);
+    await userEvent.click(navigationCheckbox);
+    await expect(navigationCheckbox).not.toBeChecked();
+    await userEvent.click(navigationCheckbox);
+    await expect(navigationCheckbox).toBeChecked();
+    await expect(canvas.queryByRole('button', { name: 'Add devices' })).toBeNull();
+    await userEvent.selectOptions(canvas.getByRole('combobox', { name: 'Group' }), 'upper-floor');
+    await expect(canvas.getByRole('combobox', { name: 'Group' })).toHaveValue('upper-floor');
+    await expect(canvas.getByRole('button', { name: 'Save changes' })).toBeEnabled();
+    await userEvent.click(canvas.getByRole('button', { name: 'Devices' }));
     await expect(canvas.getByRole('button', { name: 'Add devices' })).toBeVisible();
-    await expect(canvas.queryByRole('heading', { name: 'Devices' })).toBeNull();
-    await expect(canvas.queryByText('Review assigned devices or add another device.')).toBeNull();
     await userEvent.click(canvas.getByRole('button', { name: 'Actions: Ceiling lights' }));
     await expect(page.getByRole('menuitem', { name: 'Hide' })).toBeVisible();
     await expect(page.getByRole('menuitem', { name: 'Move' })).toBeVisible();
@@ -809,14 +819,10 @@ export const RoomDetails: Story = {
     await expect(page.getByRole('menuitem', { name: 'Show' })).toBeVisible();
     await userEvent.keyboard('{Escape}');
     await userEvent.click(canvas.getByRole('button', { name: 'Room settings' }));
-    await expect(canvas.queryByRole('button', { name: 'Add devices' })).toBeNull();
     await expect(canvas.queryByRole('button', { name: 'More actions' })).toBeNull();
     await expect(canvas.getByRole('button', { name: /^Merge room/ })).toBeVisible();
     await expect(canvas.getByRole('button', { name: /^Split room/ })).toBeVisible();
     await expect(canvas.getByRole('button', { name: /^Delete room/ })).toBeVisible();
-    await userEvent.selectOptions(canvas.getByRole('combobox', { name: 'Group' }), 'upper-floor');
-    await expect(canvas.getByRole('combobox', { name: 'Group' })).toHaveValue('upper-floor');
-    await expect(canvas.getByRole('button', { name: 'Save changes' })).toBeEnabled();
   },
 };
 
@@ -832,11 +838,11 @@ export const DeviceSelection: Story = {
     const canvas = within(canvasElement);
     const page = within(canvasElement.ownerDocument.body);
 
-    await expect(canvas.getByRole('button', { name: 'Devices' })).toHaveAttribute(
+    await expect(canvas.getByRole('button', { name: 'Room settings' })).toHaveAttribute(
       'aria-pressed',
       'true'
     );
-    await expect(canvas.queryByRole('combobox', { name: 'Group' })).toBeNull();
+    await userEvent.click(canvas.getByRole('button', { name: 'Devices' }));
     await userEvent.click(canvas.getByRole('button', { name: 'Add devices' }));
     await expect(await page.findByRole('dialog', { name: 'Add devices' })).toBeInTheDocument();
     await expect(page.getByRole('searchbox', { name: 'Search devices' })).toBeInTheDocument();
@@ -974,7 +980,6 @@ export const PhoneRoomEditor: Story = {
     await expect(canvas.getByRole('heading', { name: 'Living Room' })).toBeVisible();
     await expect(canvas.getByRole('button', { name: 'Back' })).toBeVisible();
     await expect(canvas.getByRole('button', { name: 'Save changes' })).toBeDisabled();
-    await userEvent.click(canvas.getByRole('button', { name: 'Room settings' }));
     const roomNameInput = canvas.getByRole('textbox', { name: 'Room name' });
     await expect(roomNameInput).toHaveValue('Living Room');
     await userEvent.clear(roomNameInput);

--- a/packages/app/src/features/lighting/components/light-card/__tests__/light-settings-dialog.test.tsx
+++ b/packages/app/src/features/lighting/components/light-card/__tests__/light-settings-dialog.test.tsx
@@ -65,7 +65,7 @@ describe('LightSettingsDialog', () => {
         isOpen
         onOpenChange={vi.fn()}
         name="Porch Light"
-        isOn
+        isOn={false}
         supportsBrightness={false}
         supportsColorTemperature={false}
         supportsColorControl={false}
@@ -101,5 +101,13 @@ describe('LightSettingsDialog', () => {
     expect(screen.queryByText('Presets')).not.toBeInTheDocument();
     expect(screen.queryByText('Brightness Presets')).not.toBeInTheDocument();
     expect(screen.queryByRole('slider', { name: 'Brightness' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Done' })).toHaveStyle({
+      backgroundColor: 'rgba(107, 114, 128, 0.14)',
+      borderColor: 'rgba(107, 114, 128, 0.24)',
+    });
+    expect(screen.getByRole('combobox', { name: 'Room' }).previousElementSibling).toHaveStyle({
+      backgroundColor: 'rgba(107, 114, 128, 0.14)',
+      borderColor: 'rgba(107, 114, 128, 0.24)',
+    });
   });
 });

--- a/packages/app/src/features/lighting/components/light-card/light-settings-dialog.tsx
+++ b/packages/app/src/features/lighting/components/light-card/light-settings-dialog.tsx
@@ -8,6 +8,7 @@ import {
   CustomCardTintPicker,
   IconPicker,
 } from '@navet/app/components/shared/device-editor';
+import { NEUTRAL_DIALOG_CONTROL_ACCENT } from '@navet/app/components/shared/theme/custom-card-tint-surface';
 import {
   getAccentDialogSurface,
   resolvePrimaryColorToken,
@@ -95,7 +96,7 @@ export const LightSettingsDialog = memo(function LightSettingsDialog({
   onIconChange,
   onTintColorChange,
 }: LightSettingsDialogProps) {
-  const { primaryColor, theme } = useTheme();
+  const { accentColor, primaryColor, theme } = useTheme();
   const { t } = useI18n();
   const entityType = getEntityTypeLabel(entityId) || t('lighting.type.light');
 
@@ -213,6 +214,8 @@ export const LightSettingsDialog = memo(function LightSettingsDialog({
       description={entityType}
       tabs={tabs}
       theme={theme}
+      tintColor={isOn ? tintColor : NEUTRAL_DIALOG_CONTROL_ACCENT}
+      defaultTintAccent={accentColor}
       contentSurface={dialogSurface}
       disableOpenAutoFocus
       maxWidth="md"

--- a/packages/app/src/features/lighting/components/switch-settings-dialog.tsx
+++ b/packages/app/src/features/lighting/components/switch-settings-dialog.tsx
@@ -8,6 +8,7 @@ import {
 } from '@navet/app/components/shared/device-editor';
 import {
   getInheritedDialogSectionStyle,
+  NEUTRAL_DIALOG_CONTROL_ACCENT,
   normalizeCustomCardTint,
 } from '@navet/app/components/shared/theme/custom-card-tint-surface';
 import {
@@ -218,6 +219,7 @@ export const SwitchSettingsDialog = memo(function SwitchSettingsDialog({
       description={entityType}
       tabs={tabs}
       theme={theme}
+      tintColor={isOn ? tintColor : NEUTRAL_DIALOG_CONTROL_ACCENT}
       contentSurface={dialogSurface}
       contentClassName={dialogSurfaceOverrideClassName}
       contentStyle={resolvedDialogSurfaceStyle}

--- a/packages/app/src/features/security/components/__tests__/security-camera-dashboard.test.tsx
+++ b/packages/app/src/features/security/components/__tests__/security-camera-dashboard.test.tsx
@@ -69,8 +69,10 @@ vi.mock('@navet/app/stores/settings-store', async () => {
         cameraDirectStreamUrls: Record<string, string>;
         cameraFitModes: Record<string, 'cover'>;
         cameraFitMode: 'cover';
+        cameraFullscreenHiddenAccessoryIds: Record<string, string[]>;
         updateCameraStreamPreference: () => void;
         updateCameraFitMode: () => void;
+        updateCameraFullscreenAccessoryVisibility: () => void;
       }) => unknown
     ) =>
       selector({
@@ -80,8 +82,10 @@ vi.mock('@navet/app/stores/settings-store', async () => {
         cameraDirectStreamUrls: {},
         cameraFitModes: {},
         cameraFitMode: 'cover',
+        cameraFullscreenHiddenAccessoryIds: {},
         updateCameraStreamPreference: vi.fn(),
         updateCameraFitMode: vi.fn(),
+        updateCameraFullscreenAccessoryVisibility: vi.fn(),
       }),
   };
 });

--- a/packages/app/src/features/security/components/camera-card/__tests__/camera-card-container.test.tsx
+++ b/packages/app/src/features/security/components/camera-card/__tests__/camera-card-container.test.tsx
@@ -145,6 +145,7 @@ describe('CameraCardContainer', () => {
       cameraStreamPreferences: {},
       cameraWebRtcStreamSources: {},
       cameraDirectStreamUrls: {},
+      cameraFullscreenHiddenAccessoryIds: {},
       disableAnimations: false,
       effectsQuality: 'high',
       lowPowerMode: false,
@@ -158,7 +159,14 @@ describe('CameraCardContainer', () => {
     });
     useProviderCameraLiveDataMock.mockReturnValue({
       cameraState: 'streaming',
-      companionStates: [],
+      companionStates: [
+        {
+          entityId: 'binary_sensor.front_scenario',
+          type: 'motion',
+          detected: true,
+          changedAt: '2026-08-19T20:00:00.000Z',
+        },
+      ],
       connected: true,
       deviceEntities: {},
       liveEntity: {
@@ -203,6 +211,98 @@ describe('CameraCardContainer', () => {
     vi.useRealTimers();
     resetCameraLiveStreamBudgetForTests();
     vi.unstubAllGlobals();
+  });
+
+  it('passes device sensor and light siblings to the fullscreen viewer', () => {
+    useProviderCameraTopologyMock.mockReturnValue({
+      siblingIds: ['binary_sensor.front_scenario', 'light.front_ir', 'sensor.front_temperature'],
+    });
+    useProviderCameraLiveDataMock.mockReturnValue({
+      cameraState: 'streaming',
+      companionStates: [
+        {
+          entityId: 'binary_sensor.front_scenario',
+          type: 'motion',
+          detected: true,
+          changedAt: '2026-08-19T20:00:00.000Z',
+        },
+      ],
+      connected: true,
+      deviceEntities: {
+        'binary_sensor.front_scenario': {
+          entityId: 'binary_sensor.front_scenario',
+          state: 'off',
+          attributes: { device_class: 'motion' },
+        },
+        'light.front_ir': {
+          entityId: 'light.front_ir',
+          state: 'on',
+          attributes: { brightness: 255 },
+        },
+        'sensor.front_temperature': {
+          entityId: 'sensor.front_temperature',
+          state: '18.4',
+          attributes: { unit_of_measurement: '°C' },
+        },
+      },
+      liveEntity: {
+        state: 'streaming',
+        attributes: { entity_picture: '/api/camera_proxy/camera.front' },
+      },
+      liveState: {
+        isStreamCapable: true,
+        isStillImageOnly: false,
+        motionDetectionEnabled: null,
+      },
+    });
+
+    renderWithProviders(
+      <CameraCardContainer
+        id="home_assistant:camera.front"
+        name="Front Door"
+        room="Entrance"
+        entityPicture="/api/camera_proxy/camera.front"
+        isStreamCapable
+        size="large"
+        onSizeChange={vi.fn()}
+        isEditMode={false}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open camera viewer: Front Door' }));
+
+    expect(cameraLiveViewerRenderMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        motionDetected: true,
+        accessoryEntities: expect.arrayContaining([
+          expect.objectContaining({ id: 'home_assistant:binary_sensor.front_scenario' }),
+          expect.objectContaining({ id: 'home_assistant:light.front_ir' }),
+          expect.objectContaining({ id: 'home_assistant:sensor.front_temperature' }),
+        ]),
+      })
+    );
+
+    act(() => {
+      useSettingsStore
+        .getState()
+        .updateCameraFullscreenAccessoryVisibility(
+          'home_assistant:camera.front',
+          'home_assistant:sensor.front_temperature',
+          false
+        );
+    });
+
+    const latestViewerProps = cameraLiveViewerRenderMock.mock.lastCall?.[0] as {
+      accessoryEntities: Array<{ id: string }>;
+    };
+    expect(latestViewerProps.accessoryEntities).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'home_assistant:sensor.front_temperature' }),
+      ])
+    );
+    expect(latestViewerProps.accessoryEntities).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: 'home_assistant:light.front_ir' })])
+    );
   });
 
   it('releases a live stream after an offscreen grace period', () => {

--- a/packages/app/src/features/security/components/camera-card/__tests__/camera-live-viewer.test.tsx
+++ b/packages/app/src/features/security/components/camera-card/__tests__/camera-live-viewer.test.tsx
@@ -1,13 +1,19 @@
 import type { PlatformCameraPlaybackModel } from '@navet/app/platform/provider-feature-models';
 import { cameraEntityFixtures } from '@navet/app/test/fixtures/home-assistant/entities/camera';
 import { renderWithProviders } from '@navet/app/test/render';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CameraLiveViewer } from '../camera-live-viewer';
 
-const { autoLoadStreamPlayerMock, getCameraPlaybackPlanMock } = vi.hoisted(() => ({
-  autoLoadStreamPlayerMock: { current: false },
-  getCameraPlaybackPlanMock: vi.fn(),
+const { autoLoadStreamPlayerMock, dispatchEntityCommandMock, getCameraPlaybackPlanMock } =
+  vi.hoisted(() => ({
+    autoLoadStreamPlayerMock: { current: false },
+    dispatchEntityCommandMock: vi.fn().mockResolvedValue({ accepted: true }),
+    getCameraPlaybackPlanMock: vi.fn(),
+  }));
+
+vi.mock('@navet/app/commands', () => ({
+  dispatchEntityCommand: dispatchEntityCommandMock,
 }));
 
 vi.mock('../camera-stream-player', async () => {
@@ -66,9 +72,108 @@ const defaultProps = {
 
 beforeEach(() => {
   autoLoadStreamPlayerMock.current = false;
+  dispatchEntityCommandMock.mockClear();
 });
 
 describe('CameraLiveViewer', () => {
+  it('shows camera accessory information and controls in fullscreen', async () => {
+    getCameraPlaybackPlanMock.mockResolvedValue({
+      cameraState: 'streaming',
+      snapshotResource: null,
+      supportsSnapshot: false,
+      liveTransports: [],
+      fallbackTransports: [],
+      selectedTransport: null,
+      selectedStreamResource: null,
+      supportsStreaming: false,
+      isSnapshotFallback: false,
+      shouldStartWithSnapshot: false,
+      motionDetectionEnabled: true,
+      refreshPolicy: { retryDelaysMs: [1_000] },
+    });
+
+    renderWithProviders(
+      <CameraLiveViewer
+        {...defaultProps}
+        motionDetected
+        accessoryEntities={[
+          {
+            id: 'home_assistant:binary_sensor.front_door_scenario',
+            entity: {
+              entityId: 'binary_sensor.front_door_scenario',
+              state: 'off',
+              attributes: { friendly_name: 'Object analytics scenario 1', device_class: 'motion' },
+            },
+          },
+          {
+            id: 'home_assistant:light.front_door_ir',
+            entity: {
+              entityId: 'light.front_door_ir',
+              state: 'on',
+              attributes: { friendly_name: 'Front Door IR light', brightness: 255 },
+            },
+          },
+          {
+            id: 'home_assistant:binary_sensor.front_door_daynight',
+            entity: {
+              entityId: 'binary_sensor.front_door_daynight',
+              state: 'off',
+              attributes: { friendly_name: 'Front Door DayNight', device_class: 'light' },
+            },
+          },
+          {
+            id: 'home_assistant:binary_sensor.front_door_vmd',
+            entity: {
+              entityId: 'binary_sensor.front_door_vmd',
+              state: 'unavailable',
+              attributes: { friendly_name: 'Front Door VMD 0', device_class: 'motion' },
+            },
+          },
+          {
+            id: 'home_assistant:scene.front_door_night',
+            entity: {
+              entityId: 'scene.front_door_night',
+              state: '2026-08-19T20:00:00.000Z',
+              attributes: { friendly_name: 'Night scene' },
+            },
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Motion')).toBeInTheDocument();
+    expect(screen.getByText('Day Night')).toBeInTheDocument();
+    expect(screen.queryByText('Object analytics scenario 1')).not.toBeInTheDocument();
+    expect(screen.queryByText('Front Door VMD 0')).not.toBeInTheDocument();
+
+    const lightControl = screen.getByRole('button', { name: 'IR light: On' });
+    expect(lightControl).toHaveClass('h-10');
+    expect(lightControl).toHaveTextContent('IR light');
+    fireEvent.click(lightControl);
+    expect(screen.getAllByText('IR light')).toHaveLength(2);
+    expect(screen.getByText('100%')).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.click(screen.getAllByRole('button', { name: 'IR light: On' })[1] as HTMLElement);
+    });
+    expect(dispatchEntityCommandMock).toHaveBeenCalledWith({
+      type: 'turn_off',
+      entityId: 'home_assistant:light.front_door_ir',
+    });
+
+    expect(screen.getByRole('slider', { name: 'IR light Brightness' })).toHaveAttribute(
+      'aria-valuenow',
+      '100'
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Night scene: Activate' }));
+    });
+    expect(dispatchEntityCommandMock).toHaveBeenCalledWith({
+      type: 'turn_on',
+      entityId: 'home_assistant:scene.front_door_night',
+    });
+  });
+
   it('lets the viewer switch camera view modes', async () => {
     const onCameraViewModeChange = vi.fn();
     getCameraPlaybackPlanMock.mockResolvedValue({
@@ -285,12 +390,18 @@ describe('CameraLiveViewer', () => {
     expect(screen.getByText('HLS')).toBeInTheDocument();
     expect(screen.getByTestId('camera-viewer-top-controls')).toHaveClass('z-20');
     expect(screen.getByTestId('camera-viewer-bottom-controls')).toHaveClass('z-20');
+    expect(screen.getByRole('button', { name: 'Camera view: Auto' }).parentElement).toHaveClass(
+      'ml-auto'
+    );
     expect(screen.getByTestId('camera-viewer-header-layout')).toHaveClass(
       'grid',
       'grid-cols-[minmax(0,1fr)_auto]',
       'gap-y-2'
     );
+    expect(screen.getByTestId('camera-viewer-eyebrow')).toHaveTextContent('Front DoorEntranceHLS');
+    expect(document.querySelector('h2:not(.sr-only)')).not.toBeInTheDocument();
     expect(screen.getByTestId('camera-viewer-status')).toHaveClass('col-span-2', 'row-start-2');
+    expect(screen.getByTestId('camera-viewer-live-status')).toHaveClass('h-9');
     expect(screen.getByRole('button', { name: 'Close' })).toHaveClass('h-9', 'w-9');
     expect(
       screen.queryByRole('button', { name: 'Refresh camera snapshot' })

--- a/packages/app/src/features/security/components/camera-card/__tests__/camera-settings-dialog.test.tsx
+++ b/packages/app/src/features/security/components/camera-card/__tests__/camera-settings-dialog.test.tsx
@@ -38,6 +38,7 @@ const defaultProps = {
   cameraDirectStreamUrl: '',
   cameraDirectStreamUrlError: false,
   cameraFitMode: 'cover' as const,
+  fullscreenHiddenAccessoryIds: [],
   supportedStreamPreferences: ['web_rtc', 'mse', 'hls', 'mjpeg'] as const,
   supportsStreaming: true,
   hasSnapshot: true,
@@ -47,6 +48,7 @@ const defaultProps = {
   onCameraWebRtcStreamSourceChange: vi.fn(),
   onCameraDirectStreamUrlChange: vi.fn(),
   onCameraFitModeChange: vi.fn(),
+  onFullscreenAccessoryVisibilityChange: vi.fn(),
 };
 
 describe('CameraSettingsDialog', () => {
@@ -57,6 +59,19 @@ describe('CameraSettingsDialog', () => {
     setCameraAccessoryValueMock.mockResolvedValue(undefined);
     toggleCameraAccessoryMock.mockReset();
     toggleCameraAccessoryMock.mockResolvedValue(undefined);
+  });
+
+  it('uses the neutral camera shell palette for room and Done controls', () => {
+    renderWithProviders(<CameraSettingsDialog {...defaultProps} />);
+
+    expect(screen.getByRole('button', { name: 'Done' })).toHaveStyle({
+      backgroundColor: 'rgba(107, 114, 128, 0.14)',
+      borderColor: 'rgba(107, 114, 128, 0.24)',
+    });
+    expect(screen.getByRole('combobox', { name: 'Room' }).previousElementSibling).toHaveStyle({
+      backgroundColor: 'rgba(107, 114, 128, 0.14)',
+      borderColor: 'rgba(107, 114, 128, 0.24)',
+    });
   });
 
   it('shows snapshot-backed camera view modes for snapshot-only cameras', () => {
@@ -361,6 +376,80 @@ describe('CameraSettingsDialog', () => {
     await waitFor(() =>
       expect(selectCameraAccessoryOptionMock).toHaveBeenCalledWith('select.camera_ir_mode', 'on')
     );
+  });
+
+  it('lets users choose which available sensor details appear in fullscreen', () => {
+    const onVisibilityChange = vi.fn();
+    renderWithProviders(
+      <CameraSettingsDialog
+        {...defaultProps}
+        fullscreenHiddenAccessoryIds={['home_assistant:sensor.front_door_humidity']}
+        onFullscreenAccessoryVisibilityChange={onVisibilityChange}
+        siblingEntities={[
+          {
+            id: 'home_assistant:sensor.front_door_temperature',
+            entity: {
+              state: '21',
+              attributes: { friendly_name: 'Front Door Temperature', unit_of_measurement: '°C' },
+            } as never,
+          },
+          {
+            id: 'home_assistant:sensor.front_door_humidity',
+            entity: {
+              state: '48',
+              attributes: { friendly_name: 'Front Door Humidity', unit_of_measurement: '%' },
+            } as never,
+          },
+          {
+            id: 'home_assistant:binary_sensor.front_door_motion',
+            entity: {
+              state: 'off',
+              attributes: { friendly_name: 'Front Door Motion', device_class: 'motion' },
+            } as never,
+          },
+          {
+            id: 'home_assistant:sensor.front_door_signal',
+            entity: {
+              state: 'unavailable',
+              attributes: { friendly_name: 'Front Door Signal' },
+            } as never,
+          },
+        ]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Metrics' }));
+
+    expect(screen.getByRole('checkbox', { name: /Temperature/ })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /Humidity/ })).not.toBeChecked();
+    expect(screen.queryByRole('checkbox', { name: /Motion/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('checkbox', { name: /Signal/ })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /Temperature/ }));
+    expect(onVisibilityChange).toHaveBeenCalledWith(
+      'home_assistant:sensor.front_door_temperature',
+      false
+    );
+  });
+
+  it('shows icons in the controls and metrics tab pills', () => {
+    renderWithProviders(
+      <CameraSettingsDialog
+        {...defaultProps}
+        siblingEntities={[
+          {
+            id: 'home_assistant:sensor.front_door_temperature',
+            entity: {
+              state: '21',
+              attributes: { friendly_name: 'Front Door Temperature' },
+            } as never,
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Controls' }).querySelector('svg')).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'Metrics' }).querySelector('svg')).not.toBeNull();
   });
 
   it('routes sibling number controls through the camera provider service', async () => {

--- a/packages/app/src/features/security/components/camera-card/camera-accessory-visibility.ts
+++ b/packages/app/src/features/security/components/camera-card/camera-accessory-visibility.ts
@@ -1,0 +1,25 @@
+import type { CameraAccessoryEntity } from './types';
+
+export function getCameraAccessoryDomain(accessory: CameraAccessoryEntity) {
+  return accessory.id.replace(/^[^:]+:/, '').split('.')[0] ?? '';
+}
+
+export function getCameraAccessoryDisplayName(accessory: CameraAccessoryEntity) {
+  const friendlyName = accessory.entity.attributes?.friendly_name;
+  if (typeof friendlyName === 'string' && friendlyName.trim()) return friendlyName.trim();
+
+  const nativeId = accessory.id.replace(/^[^:]+:/, '');
+  return nativeId
+    .replace(/^[^.]+\./, '')
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+export function isCameraFullscreenTelemetryAccessory(accessory: CameraAccessoryEntity) {
+  const domain = getCameraAccessoryDomain(accessory);
+  return (
+    accessory.entity.state !== 'unavailable' &&
+    domain !== 'light' &&
+    !(domain === 'binary_sensor' && accessory.entity.attributes?.device_class === 'motion')
+  );
+}

--- a/packages/app/src/features/security/components/camera-card/camera-live-viewer.tsx
+++ b/packages/app/src/features/security/components/camera-card/camera-live-viewer.tsx
@@ -1,4 +1,5 @@
-import { BaseCardDialog } from '@navet/app/components/primitives';
+import { dispatchEntityCommand } from '@navet/app/commands';
+import { BaseCardDialog, Slider } from '@navet/app/components/primitives';
 import { getThemeSurfaceTokens } from '@navet/app/components/shared/theme/theme-surface-tokens';
 import { navetControlTokens, navetIconSizeTokens } from '@navet/app/components/system/tokens';
 import {
@@ -23,12 +24,34 @@ import type {
   CameraWebRtcStreamSource,
 } from '@navet/app/stores/settings-store';
 import { isDirectCameraStreamSource } from '@navet/app/stores/settings-store';
-import { Camera, ChevronDown, RefreshCw, Scaling, Settings2, Video, X } from 'lucide-react';
+import {
+  compactRepeatedDeviceLabel,
+  compactRepeatedLabelGroup,
+} from '@navet/app/utils/compact-device-label';
+import * as Popover from '@radix-ui/react-popover';
+import {
+  Activity,
+  Camera,
+  ChevronDown,
+  Lightbulb,
+  RefreshCw,
+  Scaling,
+  Settings2,
+  Sparkles,
+  ToggleLeft,
+  Video,
+  X,
+} from 'lucide-react';
 import { type ElementType, useCallback, useEffect, useMemo, useState } from 'react';
 import {
   normalizeCameraDirectStreamUrl,
   useCameraPlaybackPlan,
 } from '../../hooks/use-camera-playback-plan';
+import {
+  getCameraAccessoryDisplayName,
+  getCameraAccessoryDomain,
+  isCameraFullscreenTelemetryAccessory,
+} from './camera-accessory-visibility';
 import {
   CAMERA_FIT_MODE_OPTIONS,
   CAMERA_STREAM_PREFERENCE_OPTIONS,
@@ -39,7 +62,7 @@ import { CameraStreamHostSlot } from './camera-stream-host-slot';
 import { CameraStreamPlayer } from './camera-stream-player';
 import type { CameraImageSourceKind } from './camera-view-mode';
 import { isOpaqueGo2RtcStreamResource } from './go2rtc-viewer-presentation';
-import type { CameraCardImageSource } from './types';
+import type { CameraAccessoryEntity, CameraCardImageSource } from './types';
 
 interface CameraLiveViewerProps {
   isOpen: boolean;
@@ -57,10 +80,12 @@ interface CameraLiveViewerProps {
   cameraFitMode?: CameraFitMode;
   isStreamCapable: boolean;
   motionDetectionEnabled: boolean | null;
+  motionDetected?: boolean;
   initialStreamResource: ResolvedPlatformResource | null;
   initialStreamTransport?: PlatformCameraTransport | null;
   initialStreamReady?: boolean;
   retainedStreamHost?: HTMLDivElement | null;
+  accessoryEntities?: CameraAccessoryEntity[];
   onRefresh: () => void;
   onOpenSettings?: () => void;
   onCameraViewModeChange: (mode: CameraViewMode) => void;
@@ -69,6 +94,265 @@ interface CameraLiveViewerProps {
 }
 
 const CAMERA_VIEWER_ACTION_BUTTON_CLASS_NAME = `relative flex ${navetControlTokens.iconButton.sizes.compact.className} shrink-0 items-center justify-center rounded-full border border-white/12 bg-black/45 text-white backdrop-blur-xl transition-colors before:absolute before:-inset-0.5 before:content-[''] hover:bg-white/12 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70`;
+const CAMERA_VIEWER_PILL_TRIGGER_CLASS_NAME = `pointer-events-auto relative flex ${navetControlTokens.button.apiSizes.default.heightClassName} min-w-0 max-w-48 cursor-pointer items-center gap-2 rounded-full border border-white/12 bg-black/45 px-3 text-xs font-semibold text-white backdrop-blur-xl transition-colors before:absolute before:inset-0 before:content-[''] hover:bg-white/12 data-[state=open]:bg-white/14 [&>*]:pointer-events-none`;
+
+function CameraAccessoryRail({
+  accessories,
+  cameraName,
+}: {
+  accessories: CameraAccessoryEntity[];
+  cameraName: string;
+}) {
+  const { t } = useI18n();
+  const [pendingEntityId, setPendingEntityId] = useState<string | null>(null);
+  const telemetryAccessories = useMemo(
+    () => accessories.filter(isCameraFullscreenTelemetryAccessory),
+    [accessories]
+  );
+  const orderedAccessories = useMemo(
+    () =>
+      [...telemetryAccessories].sort((left, right) => {
+        const priority = (accessory: CameraAccessoryEntity) => {
+          if (accessory.entity.state === 'unavailable') return 4;
+          const domain = getCameraAccessoryDomain(accessory);
+          if (domain === 'light' || domain === 'switch') return 0;
+          if (domain === 'binary_sensor' || domain === 'scene') return 1;
+          if (domain === 'sensor') return 2;
+          return 3;
+        };
+        return priority(left) - priority(right);
+      }),
+    [telemetryAccessories]
+  );
+  const compactLabels = useMemo(() => {
+    const labels = orderedAccessories.map(getCameraAccessoryDisplayName);
+    return new Map(
+      orderedAccessories.map((accessory, index) => [
+        accessory.id,
+        compactRepeatedLabelGroup(
+          compactRepeatedDeviceLabel(labels[index] ?? '', cameraName, labels),
+          labels
+        ),
+      ])
+    );
+  }, [cameraName, orderedAccessories]);
+
+  if (orderedAccessories.length === 0) return null;
+
+  const handleAction = async (accessory: CameraAccessoryEntity) => {
+    const domain = getCameraAccessoryDomain(accessory);
+    const nextCommand =
+      domain === 'scene' || accessory.entity.state !== 'on' ? 'turn_on' : 'turn_off';
+    setPendingEntityId(accessory.id);
+    try {
+      await dispatchEntityCommand({ type: nextCommand, entityId: accessory.id });
+    } finally {
+      setPendingEntityId(null);
+    }
+  };
+
+  return (
+    <fieldset
+      aria-label={t('camera.settings.title')}
+      className="pointer-events-auto m-0 flex min-w-0 gap-2 overflow-x-auto border-0 p-0 pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+    >
+      {orderedAccessories.map((accessory) => {
+        const domain = getCameraAccessoryDomain(accessory);
+        const deviceClass = accessory.entity.attributes?.device_class;
+        const isToggle = domain === 'switch' || domain === 'light';
+        const isScene = domain === 'scene';
+        const isInteractive = isToggle || isScene;
+        const isOn = accessory.entity.state === 'on';
+        const unit = accessory.entity.attributes?.unit_of_measurement;
+        const brightness = accessory.entity.attributes?.brightness;
+        const brightnessPercent =
+          domain === 'light' && typeof brightness === 'number'
+            ? Math.round((brightness / 255) * 100)
+            : null;
+        const value =
+          accessory.entity.state === 'unavailable'
+            ? t('camera.status.unavailable')
+            : domain === 'binary_sensor' && deviceClass === 'motion'
+              ? isOn
+                ? t('camera.motion.detected')
+                : t('camera.motion.clear')
+              : domain === 'binary_sensor'
+                ? isOn
+                  ? t('common.on')
+                  : t('common.off')
+                : isToggle
+                  ? `${isOn ? t('common.on') : t('common.off')}${brightnessPercent !== null ? ` · ${brightnessPercent}%` : ''}`
+                  : `${accessory.entity.state}${typeof unit === 'string' ? ` ${unit}` : ''}`;
+        const label = compactLabels.get(accessory.id) ?? getCameraAccessoryDisplayName(accessory);
+        const Icon =
+          domain === 'light' || (domain === 'binary_sensor' && deviceClass === 'light')
+            ? Lightbulb
+            : domain === 'switch'
+              ? ToggleLeft
+              : domain === 'scene'
+                ? Sparkles
+                : Activity;
+        const content = (
+          <>
+            <Icon className={`h-3.5 w-3.5 shrink-0 ${isOn ? 'text-amber-300' : 'text-white/65'}`} />
+            <span className="max-w-36 truncate text-xs font-medium text-white/78">{label}</span>
+            <span className="shrink-0 text-xs font-semibold text-white">
+              {isScene ? t('scene.activate') : value}
+            </span>
+          </>
+        );
+
+        return isInteractive ? (
+          <button
+            key={accessory.id}
+            type="button"
+            disabled={pendingEntityId === accessory.id || accessory.entity.state === 'unavailable'}
+            aria-label={`${label}: ${isScene ? t('scene.activate') : isOn ? t('common.on') : t('common.off')}`}
+            aria-pressed={isToggle ? isOn : undefined}
+            onClick={() => void handleAction(accessory)}
+            className="flex h-9 shrink-0 items-center gap-2 rounded-full border border-white/12 bg-black/55 px-3 text-white backdrop-blur-xl transition-colors hover:bg-white/14 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 disabled:opacity-50"
+          >
+            {content}
+          </button>
+        ) : (
+          <div
+            key={accessory.id}
+            className="flex h-9 shrink-0 items-center gap-2 rounded-full border border-white/12 bg-black/55 px-3 text-white backdrop-blur-xl"
+          >
+            {content}
+          </div>
+        );
+      })}
+    </fieldset>
+  );
+}
+
+function CameraLightControl({
+  cameraName,
+  lights,
+}: {
+  cameraName: string;
+  lights: CameraAccessoryEntity[];
+}) {
+  const { t } = useI18n();
+  const [pendingEntityId, setPendingEntityId] = useState<string | null>(null);
+  const [brightnessByEntityId, setBrightnessByEntityId] = useState<Record<string, number>>({});
+  const labels = useMemo(() => lights.map(getCameraAccessoryDisplayName), [lights]);
+  const isAnyLightOn = lights.some((light) => light.entity.state === 'on');
+  const controlLabel =
+    lights.length === 1
+      ? compactRepeatedDeviceLabel(labels[0] ?? '', cameraName, labels)
+      : t('lighting.type.light');
+
+  useEffect(() => {
+    setBrightnessByEntityId(
+      Object.fromEntries(
+        lights.map((light) => {
+          const brightness = light.entity.attributes?.brightness;
+          return [
+            light.id,
+            typeof brightness === 'number' ? Math.round((brightness / 255) * 100) : 100,
+          ];
+        })
+      )
+    );
+  }, [lights]);
+
+  if (lights.length === 0) return null;
+
+  const toggleLight = async (light: CameraAccessoryEntity) => {
+    setPendingEntityId(light.id);
+    try {
+      await dispatchEntityCommand({
+        type: light.entity.state === 'on' ? 'turn_off' : 'turn_on',
+        entityId: light.id,
+      });
+    } finally {
+      setPendingEntityId(null);
+    }
+  };
+
+  return (
+    <Popover.Root>
+      <Popover.Trigger asChild>
+        <button
+          type="button"
+          className={CAMERA_VIEWER_PILL_TRIGGER_CLASS_NAME}
+          aria-label={`${controlLabel}: ${isAnyLightOn ? t('common.on') : t('common.off')}`}
+        >
+          <Lightbulb
+            className={`h-3.5 w-3.5 shrink-0 ${isAnyLightOn ? 'text-amber-300' : 'text-white/72'}`}
+          />
+          <span className="min-w-0 truncate">{controlLabel}</span>
+          <ChevronDown className="h-3.5 w-3.5 shrink-0 text-white/58" />
+        </button>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          side="top"
+          align="end"
+          sideOffset={8}
+          className="z-50 w-72 rounded-2xl border border-white/12 bg-zinc-950/95 p-3 text-white shadow-2xl backdrop-blur-xl"
+        >
+          <div className="space-y-4">
+            {lights.map((light, index) => {
+              const label = compactRepeatedDeviceLabel(labels[index] ?? '', cameraName, labels);
+              const isOn = light.entity.state === 'on';
+              const brightness = brightnessByEntityId[light.id] ?? 100;
+              return (
+                <div key={light.id} className="space-y-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="min-w-0 truncate text-sm font-medium">{label}</span>
+                    <button
+                      type="button"
+                      disabled={pendingEntityId === light.id}
+                      aria-label={`${label}: ${isOn ? t('common.on') : t('common.off')}`}
+                      aria-pressed={isOn}
+                      onClick={() => void toggleLight(light)}
+                      className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-current/60 disabled:opacity-50 ${
+                        isOn
+                          ? 'border-amber-300/35 bg-amber-400/18 text-amber-200'
+                          : 'border-current/15 bg-current/8 text-current/72'
+                      }`}
+                    >
+                      <Lightbulb className="h-4 w-4" />
+                    </button>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <Slider
+                      value={brightness}
+                      min={1}
+                      max={100}
+                      ariaLabel={`${label} ${t('lighting.brightness')}`}
+                      onValueChange={(value) =>
+                        setBrightnessByEntityId((current) => ({ ...current, [light.id]: value }))
+                      }
+                      onValueCommit={(value) =>
+                        void dispatchEntityCommand({
+                          type: 'set_brightness',
+                          entityId: light.id,
+                          brightness: value,
+                        })
+                      }
+                      rootClassName="relative flex h-9 min-w-0 flex-1 touch-none items-center select-none"
+                      trackClassName="relative h-1.5 grow rounded-full bg-current/15"
+                      rangeClassName="absolute h-full rounded-full bg-amber-400"
+                      thumbClassName="block h-4 w-4 rounded-full border-2 border-white bg-amber-400 shadow-md outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+                    />
+                    <span className="w-10 text-right text-xs font-semibold tabular-nums">
+                      {brightness}%
+                    </span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          <Popover.Arrow className="fill-zinc-950" />
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}
 
 function CameraViewerDropdown<T extends string>({
   icon: Icon,
@@ -91,7 +375,7 @@ function CameraViewerDropdown<T extends string>({
         <button
           type="button"
           aria-label={`${label}: ${selectedLabel}`}
-          className={`pointer-events-auto relative flex ${navetControlTokens.button.apiSizes.default.heightClassName} min-w-0 max-w-48 cursor-pointer items-center gap-2 rounded-full border border-white/12 bg-black/45 px-3 text-xs font-semibold text-white backdrop-blur-xl transition-colors before:absolute before:inset-0 before:content-[''] hover:bg-white/12 data-[state=open]:bg-white/14 [&>*]:pointer-events-none`}
+          className={CAMERA_VIEWER_PILL_TRIGGER_CLASS_NAME}
         >
           <Icon className="h-3.5 w-3.5 shrink-0 text-white/72" />
           <span className="min-w-0 truncate">{selectedLabel}</span>
@@ -131,10 +415,12 @@ export function CameraLiveViewer({
   cameraFitMode = 'contain',
   isStreamCapable,
   motionDetectionEnabled,
+  motionDetected = false,
   initialStreamResource,
   initialStreamTransport = null,
   initialStreamReady = false,
   retainedStreamHost = null,
+  accessoryEntities = [],
   onRefresh,
   onOpenSettings,
   onCameraViewModeChange,
@@ -150,6 +436,15 @@ export function CameraLiveViewer({
   const [readyStreamIdentity, setReadyStreamIdentity] = useState<string | null>(null);
   const supportsCameraStreams = featureMatrix.cameraStreams;
   const supportsCameraSnapshot = featureMatrix.cameraSnapshot;
+  const cameraLights = useMemo(
+    () =>
+      accessoryEntities.filter(
+        (accessory) =>
+          accessory.entity.state !== 'unavailable' &&
+          accessory.id.replace(/^[^:]+:/, '').startsWith('light.')
+      ),
+    [accessoryEntities]
+  );
   const usesDirectStream = isDirectCameraStreamSource(webRtcStreamSource ?? 'provider');
   const hasConfiguredDirectStream =
     usesDirectStream && normalizeCameraDirectStreamUrl(directStreamUrl) !== null;
@@ -403,43 +698,56 @@ export function CameraLiveViewer({
             className="pointer-events-auto grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-3 gap-y-2 md:flex md:gap-3"
           >
             <div className="min-w-0">
-              <div className="flex flex-wrap items-center gap-2 text-xs font-medium text-white/76">
-                <span>{room}</span>
-                <span className="h-1 w-1 rounded-full bg-white/35" />
-                <span>{streamTypeLabel}</span>
+              <div
+                data-testid="camera-viewer-eyebrow"
+                className="flex min-w-0 items-center gap-2 text-xs font-medium text-white/76"
+              >
+                <span className="min-w-0 truncate font-semibold text-white/92">{name}</span>
+                <span className="h-1 w-1 shrink-0 rounded-full bg-white/35" />
+                <span className="shrink-0">{room}</span>
+                <span className="h-1 w-1 shrink-0 rounded-full bg-white/35" />
+                <span className="shrink-0">{streamTypeLabel}</span>
               </div>
-              <h2 className="mt-1 truncate text-lg font-semibold tracking-tight md:text-2xl">
-                {name}
-              </h2>
             </div>
 
             <div
               data-testid="camera-viewer-status"
-              className="col-span-2 row-start-2 inline-flex w-fit items-center gap-2 rounded-full border border-white/12 bg-black/45 px-3 py-1.5 text-xs font-medium text-white backdrop-blur-xl md:order-2 md:ml-auto"
+              className="col-span-2 row-start-2 flex w-fit items-center gap-2 md:order-2 md:ml-auto"
             >
-              <span
-                className={`h-2 w-2 rounded-full ${
-                  isFeedRunning
-                    ? 'bg-emerald-400 shadow-[0_0_10px_rgba(52,211,153,0.68)]'
-                    : 'bg-white/45'
-                }`}
-              />
-              <Video className="h-3.5 w-3.5 text-white/72" />
-              <span>
-                {isStreamReadinessOpaque
-                  ? t('camera.settings.webRtcStreamSource.direct')
-                  : isFeedRunning
-                    ? t('camera.status.live')
-                    : isStreamPending
-                      ? t('camera.loadingFeed')
-                      : cameraState === 'off'
-                        ? t('common.off')
-                        : cameraState === 'unavailable'
-                          ? t('camera.status.unavailable')
-                          : t('common.on')}
-              </span>
-              {playbackModel?.isSnapshotFallback ? (
-                <span className="text-white/58">{t('camera.viewer.snapshotFallback')}</span>
+              <div
+                data-testid="camera-viewer-live-status"
+                className="inline-flex h-9 items-center gap-2 rounded-full border border-white/12 bg-black/45 px-3 text-xs font-medium text-white backdrop-blur-xl"
+              >
+                <span
+                  className={`h-2 w-2 rounded-full ${
+                    isFeedRunning
+                      ? 'bg-emerald-400 shadow-[0_0_10px_rgba(52,211,153,0.68)]'
+                      : 'bg-white/45'
+                  }`}
+                />
+                <Video className="h-3.5 w-3.5 text-white/72" />
+                <span>
+                  {isStreamReadinessOpaque
+                    ? t('camera.settings.webRtcStreamSource.direct')
+                    : isFeedRunning
+                      ? t('camera.status.live')
+                      : isStreamPending
+                        ? t('camera.loadingFeed')
+                        : cameraState === 'off'
+                          ? t('common.off')
+                          : cameraState === 'unavailable'
+                            ? t('camera.status.unavailable')
+                            : t('common.on')}
+                </span>
+                {playbackModel?.isSnapshotFallback ? (
+                  <span className="text-white/58">{t('camera.viewer.snapshotFallback')}</span>
+                ) : null}
+              </div>
+              {motionDetected ? (
+                <div className="inline-flex h-9 items-center gap-1.5 rounded-full border border-amber-300/25 bg-amber-400/16 px-3 text-xs font-semibold text-amber-100 backdrop-blur-xl">
+                  <Activity className="h-3.5 w-3.5" />
+                  <span>{t('camera.motion.detected')}</span>
+                </div>
               ) : null}
             </div>
             <div className="col-start-2 row-start-1 flex shrink-0 items-center gap-3 md:order-3">
@@ -479,32 +787,36 @@ export function CameraLiveViewer({
           data-testid="camera-viewer-bottom-controls"
           className="pointer-events-none absolute inset-x-0 bottom-0 z-20 bg-gradient-to-t from-black/85 via-black/45 to-transparent pl-[calc(env(safe-area-inset-left,0px)+1rem)] pr-[calc(env(safe-area-inset-right,0px)+1rem)] pt-4 pb-[calc(env(safe-area-inset-bottom,0px)+1rem)] md:pl-[calc(env(safe-area-inset-left,0px)+1.25rem)] md:pr-[calc(env(safe-area-inset-right,0px)+1.25rem)] md:pt-5 md:pb-[calc(env(safe-area-inset-bottom,0px)+1.25rem)]"
         >
-          <div className="flex flex-wrap justify-end gap-2">
-            {!usesDirectStream && availableTransportPreferences.length > 1 ? (
+          <div className="flex min-w-0 flex-col gap-3 md:flex-row md:items-end md:justify-between">
+            <CameraAccessoryRail accessories={accessoryEntities} cameraName={name} />
+            <div className="ml-auto flex max-w-full shrink-0 flex-wrap justify-end gap-2">
+              <CameraLightControl cameraName={name} lights={cameraLights} />
+              {!usesDirectStream && availableTransportPreferences.length > 1 ? (
+                <CameraViewerDropdown
+                  icon={Video}
+                  label={t('camera.settings.streamPreference')}
+                  options={transportOptions}
+                  value={effectivePreferredTransport}
+                  onChange={onPreferredTransportChange}
+                />
+              ) : null}
+              {!isStreamReadinessOpaque ? (
+                <CameraViewerDropdown
+                  icon={Scaling}
+                  label={t('camera.settings.fitMode')}
+                  options={fitModeOptions}
+                  value={cameraFitMode}
+                  onChange={onCameraFitModeChange}
+                />
+              ) : null}
               <CameraViewerDropdown
-                icon={Video}
-                label={t('camera.settings.streamPreference')}
-                options={transportOptions}
-                value={effectivePreferredTransport}
-                onChange={onPreferredTransportChange}
+                icon={Camera}
+                label={t('camera.settings.viewMode')}
+                options={viewModeOptions}
+                value={effectiveViewMode}
+                onChange={onCameraViewModeChange}
               />
-            ) : null}
-            {!isStreamReadinessOpaque ? (
-              <CameraViewerDropdown
-                icon={Scaling}
-                label={t('camera.settings.fitMode')}
-                options={fitModeOptions}
-                value={cameraFitMode}
-                onChange={onCameraFitModeChange}
-              />
-            ) : null}
-            <CameraViewerDropdown
-              icon={Camera}
-              label={t('camera.settings.viewMode')}
-              options={viewModeOptions}
-              value={effectiveViewMode}
-              onChange={onCameraViewModeChange}
-            />
+            </div>
           </div>
         </div>
       </div>

--- a/packages/app/src/features/security/components/camera-card/camera-settings-dialog.stories.tsx
+++ b/packages/app/src/features/security/components/camera-card/camera-settings-dialog.stories.tsx
@@ -76,6 +76,7 @@ const meta = {
     cameraDirectStreamUrl: '',
     cameraDirectStreamUrlError: false,
     cameraFitMode: 'cover',
+    fullscreenHiddenAccessoryIds: [],
     supportedStreamPreferences: ['web_rtc', 'mse', 'hls', 'mjpeg'],
     supportsStreaming: true,
     hasSnapshot: true,
@@ -85,6 +86,7 @@ const meta = {
     onCameraWebRtcStreamSourceChange: () => undefined,
     onCameraDirectStreamUrlChange: () => undefined,
     onCameraFitModeChange: () => undefined,
+    onFullscreenAccessoryVisibilityChange: () => undefined,
   },
 } satisfies Meta<typeof CameraSettingsDialogStory>;
 

--- a/packages/app/src/features/security/components/camera-card/camera-settings-dialog.tsx
+++ b/packages/app/src/features/security/components/camera-card/camera-settings-dialog.tsx
@@ -1,4 +1,8 @@
-import { CardDialogChoicePill, FieldBlock } from '@navet/app/components/patterns';
+import {
+  CardDialogChoicePill,
+  FieldBlock,
+  SelectableCheckboxRow,
+} from '@navet/app/components/patterns';
 import {
   BaseCardDialogWithState,
   Input,
@@ -7,6 +11,7 @@ import {
   Switch,
 } from '@navet/app/components/primitives';
 import { DialogSectionRow } from '@navet/app/components/shared/device-editor';
+import { NEUTRAL_DIALOG_CONTROL_ACCENT } from '@navet/app/components/shared/theme/custom-card-tint-surface';
 import { getThemeSurfaceTokens } from '@navet/app/components/shared/theme/theme-surface-tokens';
 import { useI18n, useMediaQuery, useTheme } from '@navet/app/hooks';
 import type { TranslationKey } from '@navet/app/i18n';
@@ -22,20 +27,27 @@ import type {
   CameraWebRtcStreamSource,
 } from '@navet/app/stores/settings-store';
 import { isDirectCameraStreamSource } from '@navet/app/stores/settings-store';
+import {
+  compactRepeatedDeviceLabel,
+  compactRepeatedLabelGroup,
+} from '@navet/app/utils/compact-device-label';
 import { getEntityTypeLabel } from '@navet/app/utils/entity-type-label';
 import * as Popover from '@radix-ui/react-popover';
-import { Info, Settings2 } from 'lucide-react';
+import { Info, Settings2, Sliders, SlidersHorizontal } from 'lucide-react';
 import { memo, type ReactNode, useCallback, useEffect, useState } from 'react';
+import {
+  getCameraAccessoryDisplayName,
+  getCameraAccessoryDomain,
+  isCameraFullscreenTelemetryAccessory,
+} from './camera-accessory-visibility';
 import {
   CAMERA_STREAM_PREFERENCE_OPTIONS,
   CAMERA_VIEW_MODE_OPTIONS,
 } from './camera-control-options';
 import { getGo2RtcViewerPresentation } from './go2rtc-viewer-presentation';
+import type { CameraAccessoryEntity } from './types';
 
-export interface SiblingEntity {
-  id: string;
-  entity: PlatformEntitySnapshot;
-}
+export type SiblingEntity = CameraAccessoryEntity;
 
 interface CameraSettingsDialogProps {
   entityId: string;
@@ -49,6 +61,7 @@ interface CameraSettingsDialogProps {
   cameraDirectStreamUrl: string;
   cameraDirectStreamUrlError: boolean;
   cameraFitMode: CameraFitMode;
+  fullscreenHiddenAccessoryIds: string[];
   supportedStreamPreferences: readonly PlatformCameraTransport[];
   supportsStreaming: boolean;
   hasSnapshot: boolean;
@@ -58,6 +71,7 @@ interface CameraSettingsDialogProps {
   onCameraWebRtcStreamSourceChange: (source: CameraWebRtcStreamSource) => void;
   onCameraDirectStreamUrlChange: (url: string) => void;
   onCameraFitModeChange: (mode: CameraFitMode) => void;
+  onFullscreenAccessoryVisibilityChange: (accessoryEntityId: string, visible: boolean) => void;
 }
 
 function getDisplayName(entityId: string, entity: PlatformEntitySnapshot): string {
@@ -540,6 +554,62 @@ function CameraFitModeRow({
   );
 }
 
+function CameraFullscreenInformationRow({
+  cameraName,
+  accessories,
+  hiddenAccessoryIds,
+  onVisibilityChange,
+}: {
+  cameraName: string;
+  accessories: CameraAccessoryEntity[];
+  hiddenAccessoryIds: string[];
+  onVisibilityChange: (accessoryEntityId: string, visible: boolean) => void;
+}) {
+  const { t } = useI18n();
+  const { theme } = useTheme();
+  const surface = getThemeSurfaceTokens(theme);
+  const labels = accessories.map(getCameraAccessoryDisplayName);
+  const hiddenIds = new Set(hiddenAccessoryIds);
+
+  return (
+    <ul className="max-h-64 space-y-1.5 overflow-y-auto pr-1">
+      {accessories.map((accessory, index) => {
+        const label = compactRepeatedLabelGroup(
+          compactRepeatedDeviceLabel(labels[index] ?? '', cameraName, labels),
+          labels
+        );
+        const domain = getCameraAccessoryDomain(accessory);
+        const state =
+          domain === 'binary_sensor' || domain === 'switch'
+            ? accessory.entity.state === 'on'
+              ? t('common.on')
+              : t('common.off')
+            : accessory.entity.state;
+        const unit = accessory.entity.attributes?.unit_of_measurement;
+        const description = `${state}${typeof unit === 'string' ? ` ${unit}` : ''}`;
+        const isVisible = !hiddenIds.has(accessory.id);
+
+        return (
+          <li key={accessory.id}>
+            <SelectableCheckboxRow
+              checked={isVisible}
+              onCheckedChange={(checked) => onVisibilityChange(accessory.id, checked)}
+              label={<span className="block truncate">{label}</span>}
+              description={description}
+              rowClassName={`${surface.panelMuted} ${surface.border} ${surface.textPrimary}`}
+              descriptionClassName={surface.textSecondary}
+              selectedClassName={`${surface.panel} ${surface.borderStrong}`}
+              checkboxAppearance="secondary"
+              checkboxPalette="custom"
+              checkboxPaletteColor={NEUTRAL_DIALOG_CONTROL_ACCENT}
+            />
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
 export const CameraSettingsDialog = memo(function CameraSettingsDialog({
   entityId,
   name,
@@ -552,6 +622,7 @@ export const CameraSettingsDialog = memo(function CameraSettingsDialog({
   cameraDirectStreamUrl,
   cameraDirectStreamUrlError,
   cameraFitMode,
+  fullscreenHiddenAccessoryIds,
   supportedStreamPreferences,
   supportsStreaming,
   hasSnapshot,
@@ -561,11 +632,15 @@ export const CameraSettingsDialog = memo(function CameraSettingsDialog({
   onCameraWebRtcStreamSourceChange,
   onCameraDirectStreamUrlChange,
   onCameraFitModeChange,
+  onFullscreenAccessoryVisibilityChange,
 }: CameraSettingsDialogProps) {
   const { t } = useI18n();
   const { theme } = useTheme();
   const isMobileViewport = useMediaQuery('(max-width: 767px)');
   const entityType = getEntityTypeLabel(entityId);
+  const fullscreenInformationAccessories = siblingEntities.filter(
+    isCameraFullscreenTelemetryAccessory
+  );
 
   const switches = siblingEntities.filter((s) => s.id.startsWith('switch.'));
   const selects = siblingEntities.filter((s) => s.id.startsWith('select.'));
@@ -608,6 +683,18 @@ export const CameraSettingsDialog = memo(function CameraSettingsDialog({
       ) : null}
     </div>
   );
+
+  const informationTabContent =
+    fullscreenInformationAccessories.length > 0 ? (
+      <div className="space-y-6">
+        <CameraFullscreenInformationRow
+          cameraName={name}
+          accessories={fullscreenInformationAccessories}
+          hiddenAccessoryIds={fullscreenHiddenAccessoryIds}
+          onVisibilityChange={onFullscreenAccessoryVisibilityChange}
+        />
+      </div>
+    ) : undefined;
 
   const moreControlsTabContent = hasControls ? (
     <div className="space-y-6">
@@ -673,16 +760,28 @@ export const CameraSettingsDialog = memo(function CameraSettingsDialog({
     </div>
   ) : undefined;
 
-  const extraTabs = moreControlsTabContent
-    ? [
-        {
-          key: 'more-controls',
-          label: t('common.moreActions'),
-          icon: Settings2,
-          content: moreControlsTabContent,
-        },
-      ]
-    : [];
+  const extraTabs = [
+    ...(informationTabContent
+      ? [
+          {
+            key: 'metrics',
+            label: t('common.metrics'),
+            icon: Sliders,
+            content: informationTabContent,
+          },
+        ]
+      : []),
+    ...(moreControlsTabContent
+      ? [
+          {
+            key: 'more-controls',
+            label: t('common.moreActions'),
+            icon: Settings2,
+            content: moreControlsTabContent,
+          },
+        ]
+      : []),
+  ];
 
   return (
     <BaseCardDialogWithState
@@ -692,8 +791,10 @@ export const CameraSettingsDialog = memo(function CameraSettingsDialog({
       entityId={entityId}
       description={entityType}
       controlsTabContent={controlsTabContent}
+      controlsTabIcon={SlidersHorizontal}
       extraTabs={extraTabs}
       theme={theme}
+      tintColor={NEUTRAL_DIALOG_CONTROL_ACCENT}
       disableOpenAutoFocus
       maxWidth="md"
       height="capped"

--- a/packages/app/src/features/security/components/camera-card/container.tsx
+++ b/packages/app/src/features/security/components/camera-card/container.tsx
@@ -22,6 +22,11 @@ import {
   useSettingsStore,
 } from '@navet/app/stores/settings-store';
 import { detectDeviceTier } from '@navet/app/utils/detect-device-tier';
+import {
+  createProviderScopedId,
+  getProviderNativeId,
+  parseProviderScopedId,
+} from '@navet/app/utils/provider-ids';
 import { subscribeVisibilityAwareTask } from '@navet/app/utils/visibility-aware-scheduler';
 import {
   memo,
@@ -180,6 +185,9 @@ export const CameraCardContainer = memo(function CameraCardContainer({
     isDirectCameraStreamSource(cameraWebRtcStreamSource) &&
     normalizeCameraDirectStreamUrl(cameraDirectStreamUrl) !== null;
   const cameraFitMode = useSettingsStore(settingsSelectors.cameraFitModeForEntity(id));
+  const cameraFullscreenHiddenAccessoryIds = useSettingsStore(
+    settingsSelectors.cameraFullscreenHiddenAccessoryIdsForEntity(id)
+  );
   const updateCameraViewMode = useSettingsStore(settingsSelectors.updateCameraViewMode);
   const updateCameraStreamPreference = useSettingsStore(
     settingsSelectors.updateCameraStreamPreference
@@ -191,6 +199,9 @@ export const CameraCardContainer = memo(function CameraCardContainer({
     settingsSelectors.updateCameraDirectStreamUrl
   );
   const updateCameraFitMode = useSettingsStore(settingsSelectors.updateCameraFitMode);
+  const updateCameraFullscreenAccessoryVisibility = useSettingsStore(
+    settingsSelectors.updateCameraFullscreenAccessoryVisibility
+  );
   const { siblingIds: deviceEntityIds } = useProviderCameraTopology(id);
   const { cameraState, companionStates, deviceEntities, liveEntity, liveState } =
     useProviderCameraLiveData(id, deviceEntityIds);
@@ -367,18 +378,33 @@ export const CameraCardContainer = memo(function CameraCardContainer({
   const siblingEntities = useMemo(() => {
     return deviceEntityIds
       .filter((eid) => {
-        const domain = eid.split('.')[0];
-        return domain === 'switch' || domain === 'select' || domain === 'number';
+        const domain = getProviderNativeId(eid).split('.')[0];
+        return (
+          domain === 'sensor' ||
+          domain === 'binary_sensor' ||
+          domain === 'switch' ||
+          domain === 'light' ||
+          domain === 'select' ||
+          domain === 'number' ||
+          domain === 'scene'
+        );
       })
       .map((eid) => {
-        const entity = deviceEntities[eid];
-        return entity ? { id: eid, entity } : null;
+        const nativeEntityId = getProviderNativeId(eid);
+        const entity = deviceEntities[nativeEntityId];
+        const cameraProviderId = parseProviderScopedId(id)?.providerId;
+        const accessoryEntityId =
+          parseProviderScopedId(eid) || !cameraProviderId
+            ? eid
+            : createProviderScopedId(cameraProviderId, nativeEntityId);
+        return entity ? { id: accessoryEntityId, entity } : null;
       })
       .filter((entry): entry is { id: string; entity: PlatformEntitySnapshot } => entry !== null);
-  }, [deviceEntities, deviceEntityIds]);
+  }, [deviceEntities, deviceEntityIds, id]);
 
-  const motionState = companionStates.find((state) => state.type === 'motion') ?? null;
-  const motionDetected = motionState?.detected ?? false;
+  const motionStates = companionStates.filter((state) => state.type === 'motion');
+  const motionDetected = motionStates.some((state) => state.detected);
+  const motionState = motionStates.find((state) => state.detected) ?? motionStates[0] ?? null;
   const motionChangedAt = parseTimestamp(motionState?.changedAt);
   const statusChangedAt =
     parseTimestamp(liveEntity?.lastChanged) ?? parseTimestamp(liveEntity?.lastUpdated);
@@ -447,6 +473,18 @@ export const CameraCardContainer = memo(function CameraCardContainer({
     },
     [id, updateCameraFitMode]
   );
+
+  const handleFullscreenAccessoryVisibilityChange = useCallback(
+    (accessoryEntityId: string, visible: boolean) => {
+      updateCameraFullscreenAccessoryVisibility(id, accessoryEntityId, visible);
+    },
+    [id, updateCameraFullscreenAccessoryVisibility]
+  );
+
+  const fullscreenAccessoryEntities = useMemo(() => {
+    const hiddenIds = new Set(cameraFullscreenHiddenAccessoryIds);
+    return siblingEntities.filter((accessory) => !hiddenIds.has(accessory.id));
+  }, [cameraFullscreenHiddenAccessoryIds, siblingEntities]);
 
   const handleStreamError = useCallback(
     (kind: PlatformCameraTransport | 'snapshot', options?: { retryable?: boolean }) => {
@@ -618,10 +656,12 @@ export const CameraCardContainer = memo(function CameraCardContainer({
           motionDetectionEnabled={
             playbackModel?.motionDetectionEnabled ?? liveState.motionDetectionEnabled
           }
+          motionDetected={motionDetected}
           initialStreamResource={playbackModel?.selectedStreamResource ?? null}
           initialStreamTransport={shouldRenderLiveStream}
           initialStreamReady={isStreamReady}
           retainedStreamHost={streamPortalHost}
+          accessoryEntities={fullscreenAccessoryEntities}
           onRefresh={handleRefresh}
           onOpenSettings={() => setIsSettingsOpen(true)}
           onCameraViewModeChange={setViewerCameraViewMode}
@@ -647,11 +687,13 @@ export const CameraCardContainer = memo(function CameraCardContainer({
           hasSnapshot={hasSnapshot}
           lowPowerMode={lowPowerMode}
           cameraFitMode={cameraFitMode}
+          fullscreenHiddenAccessoryIds={cameraFullscreenHiddenAccessoryIds}
           onCameraViewModeChange={handleCameraViewModeChange}
           onCameraStreamPreferenceChange={handleCameraStreamPreferenceChange}
           onCameraWebRtcStreamSourceChange={handleCameraWebRtcStreamSourceChange}
           onCameraDirectStreamUrlChange={handleCameraDirectStreamUrlChange}
           onCameraFitModeChange={handleCameraFitModeChange}
+          onFullscreenAccessoryVisibilityChange={handleFullscreenAccessoryVisibilityChange}
         />
       )}
 

--- a/packages/app/src/features/security/components/camera-card/types.ts
+++ b/packages/app/src/features/security/components/camera-card/types.ts
@@ -1,4 +1,10 @@
 import type { CardSize } from '@navet/app/components/shared/card-size-selector';
+import type { PlatformEntitySnapshot } from '@navet/app/platform/provider-feature-models';
+
+export interface CameraAccessoryEntity {
+  id: string;
+  entity: PlatformEntitySnapshot;
+}
 
 export interface CameraCardImageSource {
   srcSet: string;

--- a/packages/app/src/services/__tests__/chore-store.test.ts
+++ b/packages/app/src/services/__tests__/chore-store.test.ts
@@ -413,6 +413,44 @@ describe('NJS chore workspace store', () => {
     expect(parseResponse(retry).revision).toBe(4);
   });
 
+  it('records a missed occurrence as completed late', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-11T08:00:00.000Z'));
+    const mockFs = createMockFs();
+    choreStore.setChoreStoreFsForTests(mockFs);
+    choreStore.setChoreStorePrincipalResolverForTests(() => PRINCIPAL);
+    seedOccurrenceWorkspace();
+
+    const stored = JSON.parse(mockFs.getFile(CHORE_PATH) ?? '{}');
+    stored.data.definitionsById.dishes.claimPolicy = { required: true };
+    stored.data.occurrencesById[OCCURRENCE_ID] = {
+      ...stored.data.occurrencesById[OCCURRENCE_ID],
+      status: 'missed',
+      missedAt: '2026-08-10T13:00:00.000Z',
+    };
+    mockFs.writeFileSync(CHORE_PATH, JSON.stringify(stored));
+
+    const complete = createActionRequest('complete-missed', 3, {
+      type: 'occurrence_action',
+      occurrenceId: OCCURRENCE_ID,
+      action: { type: 'complete', participantId: 'maya' },
+    });
+    choreStore.handle(complete);
+
+    expect(complete.return).toHaveBeenCalledWith(200, expect.any(String));
+    const document = parseResponse(complete);
+    expect(document.data.occurrencesById[OCCURRENCE_ID]).toMatchObject({
+      status: 'done',
+      completedBy: 'maya',
+      completedAt: '2026-08-11T08:00:00.000Z',
+    });
+    expect(document.data.occurrencesById[OCCURRENCE_ID].missedAt).toBeUndefined();
+    expect(document.data.activity.at(-1)).toMatchObject({
+      commandId: 'complete-missed',
+      type: 'completed',
+    });
+  });
+
   it('serves definitions, filtered occurrences, and cursor-based lifecycle events', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-08-11T13:00:00.000Z'));

--- a/packages/app/src/stores/__tests__/settings-store.test.ts
+++ b/packages/app/src/stores/__tests__/settings-store.test.ts
@@ -72,6 +72,13 @@ describe('useSettingsStore', () => {
       );
     useSettingsStore.getState().updateCameraWebRtcStreamSource('camera.front_door', 'direct');
     useSettingsStore.getState().updateCameraFitMode('camera.front_door', 'contain');
+    useSettingsStore
+      .getState()
+      .updateCameraFullscreenAccessoryVisibility(
+        'camera.front_door',
+        'sensor.front_door_temperature',
+        false
+      );
     useSettingsStore.getState().resetSettings();
 
     expect(useSettingsStore.getState().lowPowerMode).toBe(defaultSettings.lowPowerMode);
@@ -95,6 +102,7 @@ describe('useSettingsStore', () => {
     expect(useSettingsStore.getState().cameraDirectStreamUrls).toEqual({});
     expect(useSettingsStore.getState().cameraFitMode).toBe('cover');
     expect(useSettingsStore.getState().cameraFitModes).toEqual({});
+    expect(useSettingsStore.getState().cameraFullscreenHiddenAccessoryIds).toEqual({});
     expect(localStorage.getItem(STORE_STORAGE_KEYS.settings)).toContain('"compactMode":false');
     expect(localStorage.getItem('ha-dashboard-settings')).toBeNull();
   });
@@ -182,6 +190,47 @@ describe('useSettingsStore', () => {
     expect(useSettingsStore.getState().cameraFitModes).toEqual({
       'home_assistant:camera.front_door': 'contain',
       'home_assistant:camera.garage': 'cover',
+    });
+  });
+
+  it('stores fullscreen camera information visibility per camera', () => {
+    const state = useSettingsStore.getState();
+    state.updateCameraFullscreenAccessoryVisibility(
+      'camera.front_door',
+      'sensor.front_door_temperature',
+      false
+    );
+    state.updateCameraFullscreenAccessoryVisibility(
+      'camera.front_door',
+      'binary_sensor.front_door_sound',
+      false
+    );
+
+    expect(useSettingsStore.getState().cameraFullscreenHiddenAccessoryIds).toEqual({
+      'home_assistant:camera.front_door': [
+        'home_assistant:sensor.front_door_temperature',
+        'home_assistant:binary_sensor.front_door_sound',
+      ],
+    });
+    expect(
+      settingsSelectors.cameraFullscreenHiddenAccessoryIdsForEntity('camera.front_door')(
+        useSettingsStore.getState()
+      )
+    ).toEqual([
+      'home_assistant:sensor.front_door_temperature',
+      'home_assistant:binary_sensor.front_door_sound',
+    ]);
+
+    useSettingsStore
+      .getState()
+      .updateCameraFullscreenAccessoryVisibility(
+        'camera.front_door',
+        'sensor.front_door_temperature',
+        true
+      );
+
+    expect(useSettingsStore.getState().cameraFullscreenHiddenAccessoryIds).toEqual({
+      'home_assistant:camera.front_door': ['home_assistant:binary_sensor.front_door_sound'],
     });
   });
 

--- a/packages/app/src/stores/selectors.ts
+++ b/packages/app/src/stores/selectors.ts
@@ -26,6 +26,8 @@ function getEntitySetting<T>(record: Record<string, T>, entityId: string): T | u
   return record[canonicalEntityId] ?? record[entityId];
 }
 
+const EMPTY_STRING_ARRAY: string[] = [];
+
 /**
  * Global app error overlay (`ErrorDisplay`) — distinct from HA connection errors.
  */
@@ -155,6 +157,8 @@ export const settingsSelectors = {
   cameraFitMode: (state: SettingsState) => state.cameraFitMode,
   cameraFitModeForEntity: (entityId: string) => (state: SettingsState) =>
     getEntitySetting(state.cameraFitModes, entityId) ?? state.cameraFitMode,
+  cameraFullscreenHiddenAccessoryIdsForEntity: (entityId: string) => (state: SettingsState) =>
+    getEntitySetting(state.cameraFullscreenHiddenAccessoryIds, entityId) ?? EMPTY_STRING_ARRAY,
   ambientLightBleed: (state: SettingsState) => state.ambientLightBleed,
   weatherForecastMode: (state: SettingsState) => state.weatherForecastMode,
   weatherMetricIds: (state: SettingsState) => state.weatherMetricIds,
@@ -169,6 +173,8 @@ export const settingsSelectors = {
   updateCameraWebRtcStreamSource: (state: SettingsState) => state.updateCameraWebRtcStreamSource,
   updateCameraDirectStreamUrl: (state: SettingsState) => state.updateCameraDirectStreamUrl,
   updateCameraFitMode: (state: SettingsState) => state.updateCameraFitMode,
+  updateCameraFullscreenAccessoryVisibility: (state: SettingsState) =>
+    state.updateCameraFullscreenAccessoryVisibility,
   resetSettings: (state: SettingsState) => state.resetSettings,
 
   // Combined selectors

--- a/packages/app/src/stores/settings-store.ts
+++ b/packages/app/src/stores/settings-store.ts
@@ -75,6 +75,7 @@ export interface UserSettings {
   cameraDirectStreamUrls: Record<string, string>;
   cameraFitMode: CameraFitMode;
   cameraFitModes: Record<string, CameraFitMode>;
+  cameraFullscreenHiddenAccessoryIds: Record<string, string[]>;
   ambientLightBleed: boolean;
   weatherForecastMode: WeatherForecastMode;
   weatherMetricIds: WeatherMetricId[];
@@ -90,6 +91,11 @@ interface SettingsState extends UserSettings {
   updateCameraWebRtcStreamSource: (entityId: string, source: CameraWebRtcStreamSource) => void;
   updateCameraDirectStreamUrl: (entityId: string, url: string) => void;
   updateCameraFitMode: (entityId: string, mode: CameraFitMode) => void;
+  updateCameraFullscreenAccessoryVisibility: (
+    cameraEntityId: string,
+    accessoryEntityId: string,
+    visible: boolean
+  ) => void;
   applyImportedSettings: (settings: UserSettings) => void;
   resetSettings: () => void;
 }
@@ -127,6 +133,7 @@ export const defaultSettings: UserSettings = {
   cameraDirectStreamUrls: {},
   cameraFitMode: 'cover',
   cameraFitModes: {},
+  cameraFullscreenHiddenAccessoryIds: {},
   ambientLightBleed: true,
   weatherForecastMode: 'weekly',
   weatherMetricIds: ['precipitation', 'humidity', 'wind'],
@@ -306,6 +313,28 @@ function normalizeCameraFitModes(value: unknown): Record<string, CameraFitMode> 
   );
 }
 
+function normalizeCameraFullscreenHiddenAccessoryIds(value: unknown): Record<string, string[]> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  return normalizePersistedEntityRecord(
+    Object.fromEntries(
+      Object.entries(value).flatMap(([cameraEntityId, accessoryIds]) => {
+        if (!Array.isArray(accessoryIds)) return [];
+        const normalizedIds = Array.from(
+          new Set(
+            accessoryIds
+              .filter((entry): entry is string => typeof entry === 'string' && entry.length > 0)
+              .map((entry) => ensureCanonicalEntityId(entry))
+          )
+        );
+        return normalizedIds.length > 0 ? [[cameraEntityId, normalizedIds]] : [];
+      })
+    )
+  );
+}
+
 const knownSettingsKeys = new Set<keyof UserSettings>(
   Object.keys(defaultSettings) as Array<keyof UserSettings>
 );
@@ -391,6 +420,12 @@ export const useSettingsStore = create<SettingsState>()(
             newSettings.cameraFitModes !== undefined
               ? normalizeCameraFitModes(newSettings.cameraFitModes)
               : state.cameraFitModes,
+          cameraFullscreenHiddenAccessoryIds:
+            newSettings.cameraFullscreenHiddenAccessoryIds !== undefined
+              ? normalizeCameraFullscreenHiddenAccessoryIds(
+                  newSettings.cameraFullscreenHiddenAccessoryIds
+                )
+              : state.cameraFullscreenHiddenAccessoryIds,
           customSidebarActions:
             newSettings.customSidebarActions !== undefined
               ? normalizeCustomSidebarActions(newSettings.customSidebarActions)
@@ -444,6 +479,22 @@ export const useSettingsStore = create<SettingsState>()(
             [ensureCanonicalEntityId(entityId)]: mode,
           },
         })),
+      updateCameraFullscreenAccessoryVisibility: (cameraEntityId, accessoryEntityId, visible) =>
+        set((state) => {
+          const cameraId = ensureCanonicalEntityId(cameraEntityId);
+          const accessoryId = ensureCanonicalEntityId(accessoryEntityId);
+          const currentHiddenIds = state.cameraFullscreenHiddenAccessoryIds[cameraId] ?? [];
+          const nextHiddenIds = visible
+            ? currentHiddenIds.filter((id) => id !== accessoryId)
+            : Array.from(new Set([...currentHiddenIds, accessoryId]));
+          const nextByCamera = { ...state.cameraFullscreenHiddenAccessoryIds };
+          if (nextHiddenIds.length > 0) {
+            nextByCamera[cameraId] = nextHiddenIds;
+          } else {
+            delete nextByCamera[cameraId];
+          }
+          return { cameraFullscreenHiddenAccessoryIds: nextByCamera };
+        }),
       applyImportedSettings: (importedSettings) => {
         const supportedSettings = pickKnownSettings(importedSettings);
         return set(() => ({
@@ -484,6 +535,9 @@ export const useSettingsStore = create<SettingsState>()(
             ? supportedSettings.cameraFitMode
             : defaultSettings.cameraFitMode,
           cameraFitModes: normalizeCameraFitModes(supportedSettings.cameraFitModes),
+          cameraFullscreenHiddenAccessoryIds: normalizeCameraFullscreenHiddenAccessoryIds(
+            supportedSettings.cameraFullscreenHiddenAccessoryIds
+          ),
           customSidebarActions: normalizeCustomSidebarActions(
             supportedSettings.customSidebarActions
           ),
@@ -550,6 +604,9 @@ export const useSettingsStore = create<SettingsState>()(
             ? next.cameraFitMode
             : current.cameraFitMode,
           cameraFitModes: normalizeCameraFitModes(next.cameraFitModes),
+          cameraFullscreenHiddenAccessoryIds: normalizeCameraFullscreenHiddenAccessoryIds(
+            next.cameraFullscreenHiddenAccessoryIds
+          ),
           customSidebarActions: normalizeCustomSidebarActions(next.customSidebarActions),
           customSummaryPills: normalizeCustomSummaryPills(next.customSummaryPills),
         };

--- a/packages/app/src/stores/types.ts
+++ b/packages/app/src/stores/types.ts
@@ -103,6 +103,7 @@ interface UserSettings {
   cameraDirectStreamUrls: Record<string, string>;
   cameraFitMode: CameraFitMode;
   cameraFitModes: Record<string, CameraFitMode>;
+  cameraFullscreenHiddenAccessoryIds: Record<string, string[]>;
   ambientLightBleed: boolean;
   weatherForecastMode: WeatherForecastMode;
   weatherMetricIds: WeatherMetricId[];
@@ -118,6 +119,11 @@ export interface SettingsState extends UserSettings {
   updateCameraWebRtcStreamSource: (entityId: string, source: CameraWebRtcStreamSource) => void;
   updateCameraDirectStreamUrl: (entityId: string, url: string) => void;
   updateCameraFitMode: (entityId: string, mode: CameraFitMode) => void;
+  updateCameraFullscreenAccessoryVisibility: (
+    cameraEntityId: string,
+    accessoryEntityId: string,
+    visible: boolean
+  ) => void;
   applyImportedSettings: (settings: UserSettings) => void;
   resetSettings: () => void;
 }

--- a/packages/app/src/utils/__tests__/compact-device-label.test.ts
+++ b/packages/app/src/utils/__tests__/compact-device-label.test.ts
@@ -26,6 +26,14 @@ describe('compactRepeatedDeviceLabel', () => {
     ).toBe('Boost Mode');
   });
 
+  it('removes a camera model prefix when punctuation differs between labels', () => {
+    expect(
+      compactRepeatedDeviceLabel('AXIS M2048-LE IR Light 0', 'AXIS M2048 LE Dome Camera', [
+        'AXIS M2048-LE IR Light 0',
+      ])
+    ).toBe('IR Light 0');
+  });
+
   it('keeps the original label when trimming would empty it', () => {
     expect(compactRepeatedDeviceLabel('Pax Calima', 'Pax Calima', ['Pax Calima Boost mode'])).toBe(
       'Pax Calima'

--- a/packages/app/src/utils/compact-device-label.ts
+++ b/packages/app/src/utils/compact-device-label.ts
@@ -73,9 +73,9 @@ function stripSharedPrefix(label: string, prefixWords: readonly string[]) {
   }
 
   const humanizedLabel = humanizeLabel(label);
-  const prefixText = humanizeLabel(prefixWords.join(' '));
+  const escapedPrefixWords = prefixWords.map((word) => word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
   const prefixPattern = new RegExp(
-    `^${prefixText.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:[\\s:/_-]+|(?=[A-Z][a-z])|$)`,
+    `^${escapedPrefixWords.join('[\\s:/_-]+')}(?:[\\s:/_-]+|(?=[A-Z][a-z])|$)`,
     'i'
   );
   const strippedLabel = humanizedLabel.replace(prefixPattern, '').trim();

--- a/packages/app/src/utils/settings-profile-scope.ts
+++ b/packages/app/src/utils/settings-profile-scope.ts
@@ -50,6 +50,7 @@ export const SETTINGS_PROFILE_CLASSIFICATION = {
   cameraDirectStreamUrls: 'secret',
   cameraFitMode: 'device',
   cameraFitModes: 'device',
+  cameraFullscreenHiddenAccessoryIds: 'device',
   ambientLightBleed: 'device',
   weatherForecastMode: 'shared',
   weatherMetricIds: 'shared',
@@ -205,6 +206,20 @@ function sanitizeSettingValue(key: keyof UserSettings, value: unknown): unknown 
   if (key === 'cameraFitModes') {
     const sanitized = sanitizeRecordValues(value, CAMERA_FIT_MODES);
     return sanitized ? normalizePersistedEntityRecord(sanitized) : undefined;
+  }
+  if (key === 'cameraFullscreenHiddenAccessoryIds') {
+    if (!isRecord(value)) return undefined;
+    return normalizePersistedEntityRecord(
+      Object.fromEntries(
+        Object.entries(value).flatMap(([cameraEntityId, accessoryIds]) => {
+          if (!Array.isArray(accessoryIds)) return [];
+          const validIds = accessoryIds.filter(
+            (entry): entry is string => typeof entry === 'string' && entry.length > 0
+          );
+          return validIds.length > 0 ? [[cameraEntityId, validIds]] : [];
+        })
+      )
+    );
   }
   if (key === 'cameraDirectStreamUrls') {
     if (!isRecord(value)) {

--- a/packages/core/src/chores.test.ts
+++ b/packages/core/src/chores.test.ts
@@ -401,6 +401,33 @@ describe('chores domain', () => {
     expect(approved.activity.type).toBe('approved');
   });
 
+  it('allows an assigned participant to record a missed chore as completed late', () => {
+    const completed = applyChoreOccurrenceCommand({
+      commandId: 'command-complete-missed',
+      command: { type: 'complete', participantId: 'bob' },
+      definition: makeDefinition({
+        assignment: { mode: 'person', participantIds: ['bob'] },
+        approval: { required: true, approverIds: ['alice'] },
+        claimPolicy: { required: true, allowSteal: false },
+      }),
+      occurrence: makeOccurrence({
+        assigneeIds: ['bob'],
+        assignmentSlot: 'bob',
+        status: 'missed',
+        missedAt: '2026-08-10T20:00:00.000Z',
+      }),
+      timestamp: '2026-08-11T08:00:00.000Z',
+    });
+
+    expect(completed.occurrence).toMatchObject({
+      status: 'awaiting_approval',
+      completedBy: 'bob',
+      completedAt: '2026-08-11T08:00:00.000Z',
+    });
+    expect(completed.occurrence.missedAt).toBeUndefined();
+    expect(completed.activity.type).toBe('completed');
+  });
+
   it('does not let another participant complete a claimed occurrence', () => {
     expect(() =>
       applyChoreOccurrenceCommand({

--- a/packages/core/src/chores.ts
+++ b/packages/core/src/chores.ts
@@ -1512,10 +1512,18 @@ export function applyChoreOccurrenceCommand(
     }
     case 'complete': {
       assertAssigned(occurrence, participantId);
-      if (occurrence.status !== 'available' && occurrence.status !== 'claimed') {
-        throw new Error('Only available or claimed chores can be completed');
+      if (
+        occurrence.status !== 'available' &&
+        occurrence.status !== 'claimed' &&
+        occurrence.status !== 'missed'
+      ) {
+        throw new Error('Only available, claimed, or missed chores can be completed');
       }
-      if (occurrence.status === 'claimed' && occurrence.claimedBy !== participantId) {
+      if (
+        (occurrence.status === 'claimed' || occurrence.status === 'missed') &&
+        occurrence.claimedBy &&
+        occurrence.claimedBy !== participantId
+      ) {
         throw new Error('A claimed chore can only be completed by its claimant');
       }
       if (occurrence.status === 'available' && definition.claimPolicy?.required) {
@@ -1528,6 +1536,7 @@ export function applyChoreOccurrenceCommand(
         claimedAt: occurrence.claimedAt ?? timestamp,
         completedBy: participantId,
         completedAt: timestamp,
+        missedAt: undefined,
         updatedAt: timestamp,
       };
       break;


### PR DESCRIPTION
## What changed

- reduce false dashboard-profile conflict notifications for independent devices and keep routine dashboard updates unobtrusive
- align chores with motivation-off settings, support completing missed chores, and redesign Add/Edit Chore around clearer grouped options
- make shared card dialogs, room selectors, light controls, and camera dialogs consistently palette-aware
- extend fullscreen camera feeds with configurable information, motion state, and interactive accessory controls
- ignore hidden unavailable cameras in room security alerts
- redesign Room settings so navigation visibility is immediate and the form follows Navet's visual hierarchy
- document the visual hierarchy contract in the UI guidelines

## Why

Several related dashboard workflows exposed noisy synchronization, settings that did not reflect user preferences, and configuration surfaces whose hierarchy and theme treatment were inconsistent with Navet. This consolidates those fixes into a coherent interaction and presentation pass.

## Validation

- normal commit hooks: lockfile policy, Biome, Storybook standards, UI-kit boundaries, Conventional Commits
- TypeScript `tsc --noEmit`
- Tier 1: 43 files, 581 tests passed
- Tier 2: 22 files, 151 tests passed
- focused Room Workspace Storybook: 18 tests passed
- desktop and phone visual review of Room settings