### PR TITLE
fix(hacs): preserve default repository compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ concurrency:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/navet
-  HACS_REPOSITORY: awesomestvi/navet-hacs
+  HACS_REPOSITORY: awesomestvi/navet-home-assistant
 
 jobs:
   release-context:
@@ -296,7 +296,7 @@ jobs:
           app-id: ${{ secrets.NAVET_HACS_APP_ID }}
           private-key: ${{ secrets.NAVET_HACS_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          repositories: navet-hacs
+          repositories: navet-home-assistant
 
       - name: Checkout HACS repository
         if: steps.hacs_preflight.outputs.enabled == 'true'

--- a/docs/HOME_ASSISTANT.md
+++ b/docs/HOME_ASSISTANT.md
@@ -34,7 +34,7 @@ use the **Home Assistant App**.
 4. Paste this address:
 
    ```text
-   https://github.com/awesomestvi/navet-hacs
+   https://github.com/awesomestvi/navet-home-assistant
    ```
 
 5. Choose **Integration** as the category, then add the repository.

--- a/docs/NAVET_DEV.md
+++ b/docs/NAVET_DEV.md
@@ -175,12 +175,13 @@ exact branch build on a household dashboard.
 ## HACS Custom Panel
 
 HACS installs the stable Navet custom-panel release from
-`https://github.com/awesomestvi/navet-hacs`. The Navet Dev publish workflow does not update that
-repository, so there is no supported `Navet Dev` HACS channel.
+`https://github.com/awesomestvi/navet-home-assistant`. The Navet Dev publish workflow does not
+update that repository, so there is no supported `Navet Dev` HACS channel.
 
 For the supported stable installation:
 
-1. Add `https://github.com/awesomestvi/navet-hacs` to HACS as an `Integration` custom repository.
+1. Add `https://github.com/awesomestvi/navet-home-assistant` to HACS as an `Integration` custom
+   repository.
 2. Install `Navet`.
 3. Restart Home Assistant.
 4. Add `Navet` from `Settings -> Devices & services`.
@@ -226,8 +227,8 @@ this manual build with the latest stable release.
 
 - Home Assistant App: stop `Navet Dev`, install or start the stable `Navet` App, and verify its configuration.
 - Docker: change `ghcr.io/awesomestvi/navet:dev` to `ghcr.io/awesomestvi/navet:latest`.
-- Custom panel: install or redownload Navet from the `awesomestvi/navet-hacs` repository and restart
-  Home Assistant.
+- Custom panel: install or redownload Navet from the `awesomestvi/navet-home-assistant` repository
+  and restart Home Assistant.
 
 Development and stable installations may not share the same storage location. Export important
 dashboard configuration before switching rather than assuming it will appear in the other runtime.

--- a/docs/agents/release-and-publishing.md
+++ b/docs/agents/release-and-publishing.md
@@ -77,7 +77,7 @@ Important note:
   refreshes Docker `edge` and `dev`, and advances the supervised `Navet Dev` add-on surface
 - install a non-main publish by its exact immutable Docker version; do not expect the moving aliases
   or Add-on Store to select it
-- dev publishes do not sync `awesomestvi/navet-hacs` and do not create HACS updates
+- dev publishes do not sync `awesomestvi/navet-home-assistant` and do not create HACS updates
 
 ## Release Notes
 
@@ -141,8 +141,8 @@ Fallback source:
 - Tier 2 remains blocking for main CI
 - Tier 3 remains visible but non-release-blocking
 - tagged releases build the custom-panel artifact in workflow
-- tagged releases sync the exported HACS payload into `awesomestvi/navet-hacs/main`
-- tagged releases also create or refresh the matching Git tag in `awesomestvi/navet-hacs`
+- tagged releases sync the exported HACS payload into `awesomestvi/navet-home-assistant/main`
+- tagged releases also create or refresh the matching Git tag in `awesomestvi/navet-home-assistant`
 - local `pnpm sync:hacs` is still useful for previewing export output before release work
 
 ## Publishing Rules

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -46,7 +46,7 @@ add-on release, even when it mostly mirrors the main app changelog.
 
 Home Assistant packaging uses two public repository surfaces:
 
-- `awesomestvi/navet-hacs` contains only HACS integration files at its repository root
+- `awesomestvi/navet-home-assistant` contains only HACS integration files at its repository root
 - `awesomestvi/navet` remains the Home Assistant add-on repository root and must keep
   `repository.yaml` at the repo root
 
@@ -179,8 +179,8 @@ Behavior:
 
 - validates release-managed files and changelog alignment
 - requires Tier 1 validation
-- syncs the release HACS payload into `awesomestvi/navet-hacs/main`
-- creates or refreshes the matching `awesomestvi/navet-hacs` Git tag for the release
+- syncs the release HACS payload into `awesomestvi/navet-home-assistant/main`
+- creates or refreshes the matching `awesomestvi/navet-home-assistant` Git tag for the release
 - pins Node 22 anywhere the workflow runs repo JavaScript
 - builds the custom panel assets in workflow and attaches a panel archive
 - publishes standalone app release images
@@ -223,8 +223,8 @@ not part of tagged release promotion in phase 1.
 8. Create and push the release tag for `awesomestvi/navet`.
 9. Let the tagged release workflow build the panel bundle, package it, and attach
     `navet-panel-<tag>.tar.gz` to the GitHub release.
-10. Verify the published standalone/add-on artifacts, the matching `navet-hacs` branch/tag sync, and
-    the GitHub release page.
+10. Verify the published standalone/add-on artifacts, the matching `navet-home-assistant`
+    branch/tag sync, and the GitHub release page.
 
 Optional immutable Navet Dev publish:
 
@@ -247,7 +247,8 @@ Optional immutable Navet Dev publish:
 - checking Linear `Ready for Release` scope and deciding whether the commit-history fallback is needed
 - drafting release notes
 - keeping the HA panel source buildable when the automated export/release workflows rebuild it
-- monitoring the automatic `navet-hacs` sync from `main` and tagged releases, and stepping in if that repo rejects a push
+- monitoring the automatic `navet-home-assistant` sync from `main` and tagged releases, and
+  stepping in if that repo rejects a push
 - updating `platform/home-assistant/addons/navet/CHANGELOG.md` for every add-on release
 - final runtime sanity checks for Home Assistant panel and add-on installs
 - choosing when to publish an immutable branch build and when to promote `main` to the shared Navet

--- a/platform/home-assistant/custom_components/navet/README.md
+++ b/platform/home-assistant/custom_components/navet/README.md
@@ -1,14 +1,14 @@
 # Navet Home Assistant Panel
 
 This custom integration registers Navet as a Home Assistant sidebar panel.
-This directory is the canonical monorepo source exported to `awesomestvi/navet-hacs`.
+This directory is the canonical monorepo source exported to `awesomestvi/navet-home-assistant`.
 The generated `frontend/` bundle is assembled during export and is tracked only in the published
 HACS repository, not in this monorepo.
 
 ## Install With HACS
 
-1. Add `https://github.com/awesomestvi/navet-hacs` as a HACS custom repository with category
-   `Integration`.
+1. Add `https://github.com/awesomestvi/navet-home-assistant` as a HACS custom repository with
+   category `Integration`.
 2. Download `Navet`.
 3. Restart Home Assistant.
 4. Add the `Navet` integration from `Settings -> Devices & services`.

--- a/scripts/assemble-ha-integration.mjs
+++ b/scripts/assemble-ha-integration.mjs
@@ -27,6 +27,8 @@ export async function assembleHomeAssistantIntegration({
     filter: (sourcePath) => !isInsideFrontend(sourceRoot, sourcePath),
   });
   await cp(panelDist, resolve(destination, 'frontend'), { recursive: true });
+  await rm(resolve(destination, 'frontend/.vite'), { recursive: true, force: true });
+  await rm(resolve(destination, 'frontend/wallpapers/generated/manifest.json'), { force: true });
 
   return {
     destination,

--- a/scripts/create-dev-release.test.mjs
+++ b/scripts/create-dev-release.test.mjs
@@ -35,7 +35,7 @@ function createReleaseFixture() {
   const emptyHooksDirectory = join(root, 'empty-hooks');
   const globalGitConfig = join(root, 'global.gitconfig');
   const environment = {
-    ...process.env,
+    ...Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith('GIT_'))),
     GIT_AUTHOR_EMAIL: 'navet-release-test@example.com',
     GIT_AUTHOR_NAME: 'Navet Release Test',
     GIT_COMMITTER_EMAIL: 'navet-release-test@example.com',

--- a/scripts/ha-integration-packaging.test.mjs
+++ b/scripts/ha-integration-packaging.test.mjs
@@ -25,12 +25,17 @@ describe('Home Assistant integration packaging', () => {
     const destination = join(root, 'export', 'custom_components', 'navet');
 
     await mkdir(join(sourceRoot, 'frontend'), { recursive: true });
+    await mkdir(join(panelDist, '.vite'), { recursive: true });
     await mkdir(join(panelDist, 'assets'), { recursive: true });
+    await mkdir(join(panelDist, 'wallpapers', 'generated'), { recursive: true });
     await writeFile(join(sourceRoot, '__init__.py'), '# integration source\n');
     await writeFile(join(sourceRoot, 'frontend', 'navet-panel.js'), 'stale panel\n');
     await writeFile(join(panelDist, 'navet-panel.js'), 'fresh panel\n');
     await writeFile(join(panelDist, 'navet-ha-shell.js'), 'fresh shell\n');
     await writeFile(join(panelDist, 'assets', 'app.js'), 'fresh chunk\n');
+    await writeFile(join(panelDist, '.vite', 'manifest.json'), '{}\n');
+    await writeFile(join(panelDist, 'wallpapers', 'generated', 'manifest.json'), '{}\n');
+    await writeFile(join(panelDist, 'wallpapers', 'generated', 'aurora.webp'), 'wallpaper\n');
 
     await assembleHomeAssistantIntegration({ sourceRoot, panelDist, destination });
 
@@ -46,6 +51,15 @@ describe('Home Assistant integration packaging', () => {
     await expect(readFile(join(destination, 'frontend', 'assets', 'app.js'), 'utf8')).resolves.toBe(
       'fresh chunk\n'
     );
+    await expect(
+      readFile(join(destination, 'frontend', '.vite', 'manifest.json'), 'utf8')
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(
+      readFile(join(destination, 'frontend', 'wallpapers', 'generated', 'manifest.json'), 'utf8')
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(
+      readFile(join(destination, 'frontend', 'wallpapers', 'generated', 'aurora.webp'), 'utf8')
+    ).resolves.toBe('wallpaper\n');
   });
 
   it('keeps tagged panel artifacts build-owned instead of checkout-owned', async () => {

--- a/scripts/release-surfaces.mjs
+++ b/scripts/release-surfaces.mjs
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import process from 'node:process';
-import { resolve } from 'node:path';
+import { relative, resolve } from 'node:path';
 import { homeAssistantPaths, repoRoot } from './repo-paths.mjs';
 
 export const root = repoRoot;
@@ -167,6 +167,17 @@ export function fail(message) {
   process.exit(1);
 }
 
+function findFilesNamed(directory, filename) {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = resolve(directory, entry.name);
+    if (entry.isDirectory()) {
+      return findFilesNamed(entryPath, filename);
+    }
+
+    return entry.isFile() && entry.name === filename ? [entryPath] : [];
+  });
+}
+
 export function assertMainRepositoryMetadata() {
   if (!fs.existsSync(repositoryMetadataPath)) {
     throw new Error(`Required root repository.yaml is missing: ${repositoryMetadataPath}.`);
@@ -219,16 +230,23 @@ export function assertHacsExport(exportRoot) {
   }
 
   const requiredPanelFiles = [
-    'custom_components/navet/frontend/.vite/manifest.json',
     'custom_components/navet/frontend/navet-panel.js',
     'custom_components/navet/frontend/navet-ha-shell.js',
     'custom_components/navet/frontend/logo.svg',
-    'custom_components/navet/frontend/wallpapers/generated/manifest.json',
   ];
   for (const entry of requiredPanelFiles) {
     if (!fs.existsSync(resolve(exportRoot, entry))) {
       throw new Error(`HACS export is missing generated panel asset: ${resolve(exportRoot, entry)}`);
     }
+  }
+
+  const manifestFiles = findFilesNamed(exportRoot, 'manifest.json').map((entry) =>
+    relative(exportRoot, entry)
+  );
+  if (manifestFiles.length !== 1 || manifestFiles[0] !== 'custom_components/navet/manifest.json') {
+    throw new Error(
+      `HACS export must contain only the integration manifest.json, received: ${manifestFiles.join(', ')}`
+    );
   }
 
   const forbiddenPaths = ['repository.yaml', 'platform'];


### PR DESCRIPTION
## Summary

- update release automation and documentation for the renamed `awesomestvi/navet-home-assistant` repository
- exclude frontend build metadata named `manifest.json` from HACS exports so upstream Hassfest can discover the integration manifest unambiguously
- guard future exports and cover the behavior with packaging tests
- isolate Git fixture repositories from hook-provided `GIT_*` variables so pre-push validation is safe in linked worktrees

## Validation

- `node_modules/.bin/vitest run scripts/ha-integration-packaging.test.mjs`
- `python3 -m unittest discover -s platform/home-assistant/tests -p 'test_*.py'` (25 passed)\n- `node scripts/check-release-surfaces.mjs`\n- mandatory pre-commit checks\n- mandatory pre-push checks: TypeScript, Tier 1 (824 tests), Tier 2 (156 tests)