### PR TITLE
docs(hacs): explain repository rename

### DIFF
--- a/docs/HOME_ASSISTANT.md
+++ b/docs/HOME_ASSISTANT.md
@@ -47,6 +47,16 @@ use the **Home Assistant App**.
 That is all. Navet uses your current Home Assistant session. You do not need a separate Navet
 account, Home Assistant address, or access token.
 
+## Already Installed From `navet-hacs`?
+
+No action is required. The repository was renamed from `awesomestvi/navet-hacs` to
+`awesomestvi/navet-home-assistant`, and GitHub redirects the old address.
+
+If HACS cannot fetch an update, remove only the old custom repository entry, add
+`https://github.com/awesomestvi/navet-home-assistant` as an `Integration` repository, then
+redownload Navet and restart Home Assistant. Keep the Navet integration installed; you do not need
+to clear your dashboard configuration.
+
 ## Option 2: Install the Home Assistant App
 
 ### What you need

--- a/platform/home-assistant/custom_components/navet/README.md
+++ b/platform/home-assistant/custom_components/navet/README.md
@@ -14,6 +14,16 @@ HACS repository, not in this monorepo.
 4. Add the `Navet` integration from `Settings -> Devices & services`.
 5. Open Navet from the Home Assistant sidebar.
 
+## Already Installed From `navet-hacs`?
+
+No action is required. The repository was renamed from `awesomestvi/navet-hacs` to
+`awesomestvi/navet-home-assistant`, and GitHub redirects the old address.
+
+If HACS cannot fetch an update, remove only the old custom repository entry, add
+`https://github.com/awesomestvi/navet-home-assistant` as an `Integration` repository, then
+redownload Navet and restart Home Assistant. Keep the Navet integration installed; you do not need
+to clear your dashboard configuration.
+
 ## Current Behavior
 
 - registers the `/navet` panel

--- a/platform/home-assistant/repo-templates/hacs/README.md
+++ b/platform/home-assistant/repo-templates/hacs/README.md
@@ -3,6 +3,16 @@
 Navet has been downloaded through HACS. Complete the Home Assistant setup once, then open your
 dashboard directly from the sidebar.
 
+## Already Installed From `navet-hacs`?
+
+No action is required. The repository was renamed from `awesomestvi/navet-hacs` to
+`awesomestvi/navet-home-assistant`, and GitHub redirects the old address.
+
+If HACS cannot fetch an update, remove only the old custom repository entry, add
+`https://github.com/awesomestvi/navet-home-assistant` as an `Integration` repository, then
+redownload Navet and restart Home Assistant. Keep the Navet integration installed; you do not need
+to clear your dashboard configuration.
+
 ## Open Your Dashboard
 
 1. Restart Home Assistant after downloading or updating Navet.


### PR DESCRIPTION
## Summary

- tell existing `navet-hacs` users that no action is normally required
- document the recovery steps if HACS cannot fetch an update
- keep the notice aligned across the public Home Assistant guide, integration README, and published HACS README template

## Validation

- `pnpm docs:build`
- mandatory pre-commit checks
- mandatory pre-push checks: TypeScript, Tier 1 (824 tests), Tier 2 (156 tests)